### PR TITLE
fix(TextField): #88 - Icon now aligns correctly in small TextField

### DIFF
--- a/libs/react-components/community/src/components/form/textfield/textfield.module.scss
+++ b/libs/react-components/community/src/components/form/textfield/textfield.module.scss
@@ -106,7 +106,7 @@
   }
 
   .textfield--small & {
-    padding: 0.5rem;
+    padding: 0.25rem;
   }
 
   .textfield__input[aria-invalid='true'] + & {
@@ -131,6 +131,6 @@ div.textfield__icon-wrapper {
   }
 
   &.textfield--with-icon .textfield__input {
-    padding-right: 1rem;
+    padding-right: 1.5rem;
   }
 }


### PR DESCRIPTION
https://harlespilter.github.io/tedi-design-system/bugfix/88-icon-alignment/?path=/story/community-components-form-textfield--small

Closes: https://github.com/TEHIK-EE/tedi-design-system/issues/88 