### PR TITLE
fix(select): #103 - Improve placeholder contrast

### DIFF
--- a/libs/react-components/community/src/components/form/select/select.module.scss
+++ b/libs/react-components/community/src/components/form/select/select.module.scss
@@ -127,6 +127,10 @@ div.select__multi-value-item {
   .select__value-container--is-multi {
     gap: 0.25rem;
   }
+
+  .select__value-container .select__placeholder {
+    color: var(--color-text-subtle);
+  }
 }
 
 .select--tags-row {


### PR DESCRIPTION
Using text-suble bumps contrast up to an adequate 6.21

![image](https://github.com/user-attachments/assets/1f9f1e90-643c-4938-b9f1-ad494935652e)


https://nibbydev.github.io/tedi-design-system/rc/?path=/docs/community-components-form-select--docs
