### PR TITLE
fix(table): #48 - add scope col to table headers for a11y

### DIFF
--- a/libs/react-components/community/src/components/table/components/table-layout/table-layout.tsx
+++ b/libs/react-components/community/src/components/table/components/table-layout/table-layout.tsx
@@ -194,6 +194,7 @@ const TableLayout = <TData extends DefaultTData<TData>>(): JSX.Element | null =>
           <tr key={headerGroup.id}>
             {headerGroup.headers.map((header) => (
               <th
+                scope="col"
                 key={header.id}
                 style={{ width: header.getSize() }}
                 className={cn({ [styles['th--sortable']]: header.column.getCanSort() })}
@@ -238,7 +239,7 @@ const TableLayout = <TData extends DefaultTData<TData>>(): JSX.Element | null =>
             <tr key={footerGroup.id}>
               {footerGroup.headers.map((header, index) =>
                 header.column.columnDef.footer ? (
-                  <th key={header.id} colSpan={footerColSpan(footerGroup.headers.slice(index + 1))}>
+                  <th scope="col" key={header.id} colSpan={footerColSpan(footerGroup.headers.slice(index + 1))}>
                     {header.isPlaceholder ? null : flexRender(header.column.columnDef.footer, header.getContext())}
                   </th>
                 ) : null


### PR DESCRIPTION
Fix for Table headers for when JAWS reads cell data, then it also reads the header before.
https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html