### PR TITLE
feat(separator): add height to Vertical Separator, deprecate fullWidth to isStretched #218

### DIFF
--- a/libs/react-components/community/src/components/separator/separator.module.scss
+++ b/libs/react-components/community/src/components/separator/separator.module.scss
@@ -15,6 +15,8 @@ $sizes: (
 );
 
 .separator {
+  --vertical-separator-height: 100%;
+
   position: relative;
   display: block;
   margin: 0;
@@ -24,7 +26,7 @@ $sizes: (
   @include mixins.print-grayscale;
 
   &--vertical {
-    height: 100%;
+    height: var(--vertical-separator-height);
     border-top: 0;
     border-left: 1px solid var(--color-border-default);
   }
@@ -70,7 +72,7 @@ $sizes: (
   transform: translateX(-5px);
 }
 
-.separator--full-width {
+.separator--is-stretched {
   margin-right: calc(var(--card-content-padding-right) * -1);
   margin-left: calc(var(--card-content-padding-left) * -1);
 
@@ -81,15 +83,15 @@ $sizes: (
 }
 
 @each $size, $value in $sizes {
-  .separator.separator--top-#{$size} {
+  .separator--horizontal.separator--top-#{$size} {
     margin-top: #{$value};
   }
 
-  .separator.separator--bottom-#{$size} {
+  .separator--horizontal.separator--bottom-#{$size} {
     margin-bottom: #{$value};
   }
 
-  .separator.separator--spacing-#{$size} {
+  .separator--horizontal.separator--spacing-#{$size} {
     margin-top: #{$value};
     margin-bottom: #{$value};
   }

--- a/libs/react-components/community/src/components/separator/separator.stories.tsx
+++ b/libs/react-components/community/src/components/separator/separator.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { Col, Row } from '../../../../tedi/src/components/grid';
 import { VerticalSpacing } from '../../../../tedi/src/components/vertical-spacing';
+import Button from '../button/button';
 import { Card, CardContent } from '../card';
 import { Text } from '../typography/text/text';
 import Separator, { SeparatorProps } from './separator';
@@ -163,4 +164,29 @@ export const VerticalDotted: Story = {
 export const VerticalDottedSmall: Story = {
   render: TemplateVertical,
   args: { axis: 'vertical', variant: 'dotted-small', color: 'accent', fullWidth: true },
+};
+
+const TemplateCustomHeight: StoryFn<SeparatorProps> = (args) => (
+  <Row alignItems="center">
+    <Col xs="auto" md={2}>
+      <p className="text-right">12.12.2012</p>
+    </Col>
+    <Col width="auto">
+      <Separator {...args} />
+    </Col>
+    <Col>
+      <Button>Button</Button>
+    </Col>
+  </Row>
+);
+
+/**
+ * Height property can be used to set custom height of vertical separator. Mainly used when separating vertically two components. And design needs the separator follow the height of the smaller component.
+ */
+export const VerticalCustomHeight: Story = {
+  render: TemplateCustomHeight,
+  args: {
+    axis: 'vertical',
+    height: 1.5,
+  },
 };

--- a/libs/react-components/community/src/components/separator/separator.tsx
+++ b/libs/react-components/community/src/components/separator/separator.tsx
@@ -1,10 +1,11 @@
 import cn from 'classnames';
+import { CSSProperties } from 'react';
 
 import styles from './separator.module.scss';
 
 export type SeparatorSpacing = 0 | 0.25 | 0.5 | 0.75 | 1 | 1.25 | 1.5 | 1.75 | 2 | 2.5 | 5;
 
-export interface SeparatorProps {
+export interface SeparatorSharedProps {
   /**
    * Additional class.
    */
@@ -15,25 +16,14 @@ export interface SeparatorProps {
    */
   element?: 'hr' | 'div' | 'span';
   /**
+   * Whether the separator should stretch to fill the full spacing inside cardContent.
+   */
+  isStretched?: boolean;
+  /**
    * Full-width separator.
+   * @deprecated use `isStretched` instead
    */
   fullWidth?: boolean;
-  /**
-   * Spacing on top and bottom of separator
-   */
-  spacing?: SeparatorSpacing;
-  /**
-   * Spacing on top of separator. Ignored when spacing is also used
-   */
-  topSpacing?: SeparatorSpacing;
-  /**
-   * Spacing on bottom of separator. Ignored when spacing is also used
-   */
-  bottomSpacing?: SeparatorSpacing;
-  /*
-   * X/Y axis
-   */
-  axis?: 'vertical'; // and 'horizontal', which is default
   /*
    * Color of separator
    * @default default
@@ -50,18 +40,57 @@ export interface SeparatorProps {
   thickness?: 1 | 2;
 }
 
+export interface SeparatorVerticalProps extends SeparatorSharedProps {
+  /**
+   * Height of separator. Use with vertical axis, when full-width separator is not needed.
+   * Height can be number in rem units. It's customizable to allow for more flexibility around X components.
+   */
+  height?: number;
+  /**
+   * Axis of separator, vertical and horizontal separators support different props
+   */
+  axis: 'vertical';
+  spacing?: undefined;
+  topSpacing?: undefined;
+  bottomSpacing?: undefined;
+}
+
+export interface SeparatorHorizontalProps extends SeparatorSharedProps {
+  /**
+   * Spacing on top and bottom of separator. Only for horizontal axis.
+   */
+  spacing?: SeparatorSpacing;
+  /**
+   * Spacing on top of separator. Ignored when spacing is also used. Only for horizontal axis.
+   */
+  topSpacing?: SeparatorSpacing;
+  /**
+   * Spacing on bottom of separator. Ignored when spacing is also used. Only for horizontal axis.
+   */
+  bottomSpacing?: SeparatorSpacing;
+  /**
+   * Axis of separator, vertical and horizontal separators support different props
+   */
+  axis?: 'horizontal';
+  height?: undefined;
+}
+
+export type SeparatorProps = SeparatorHorizontalProps | SeparatorVerticalProps;
+
 export const Separator = (props: SeparatorProps): JSX.Element => {
   const {
     className,
     element: Element = 'div',
     fullWidth,
+    isStretched,
     spacing,
     topSpacing,
     bottomSpacing,
-    axis,
+    axis = 'horizontal',
     color = 'default',
     variant,
     thickness = 1,
+    height,
     ...rest
   } = props;
 
@@ -69,16 +98,24 @@ export const Separator = (props: SeparatorProps): JSX.Element => {
     styles['separator'],
     className,
     { [styles[`separator--${color}`]]: color },
-    { [styles['separator--vertical']]: axis === 'vertical' },
+    { [styles[`separator--${axis}`]]: axis },
     { [styles[`separator--${variant}`]]: variant },
     { [styles[`separator--thickness-${thickness}`]]: thickness && !variant },
-    { [styles['separator--full-width']]: fullWidth },
+    { [styles['separator--is-stretched']]: fullWidth || isStretched },
     { [styles[`separator--spacing-${spacing}`.replace('.', '-')]]: spacing },
     { [styles[`separator--top-${topSpacing}`.replace('.', '-')]]: !spacing && topSpacing },
     { [styles[`separator--bottom-${bottomSpacing}`.replace('.', '-')]]: !spacing && bottomSpacing }
   );
 
-  return <Element data-name="separator" {...rest} className={SeparatorBEM} />;
+  const getCssVars = () => {
+    const cssvars: CSSProperties = {};
+
+    if (height) cssvars['--vertical-separator-height'] = `${height}rem`;
+
+    return cssvars;
+  };
+
+  return <Element data-name="separator" {...rest} style={getCssVars()} className={SeparatorBEM} />;
 };
 
 export default Separator;


### PR DESCRIPTION
#218

Changed:
* Depracted `fullWidth` to use `isStretched` that is more semantical for vertical separator too
* Split Vertical and Horizontal separator props to different interfaces, not breaking because currently using those properties with verticalSpacing didn't do anything. (spacing, bottomSpacing, topSpacing)
* Add height to SeparatorVerticalProps, that allows user to customize height.