### PR TITLE
fix(truncate): fix truncate button #394

### DIFF
--- a/libs/react-components/src/tedi/components/truncate/truncate.spec.tsx
+++ b/libs/react-components/src/tedi/components/truncate/truncate.spec.tsx
@@ -10,19 +10,25 @@ describe('Truncate Component', () => {
     maxLength: 20,
   };
 
-  it('renders truncated text with ellipsis by default', () => {
+  it('handles ellipsis rendering', () => {
     render(<Truncate {...defaultProps} />);
     const truncatedText = screen.getByText(/This is a long text/);
-
     expect(truncatedText).toBeInTheDocument();
-    expect(truncatedText).toHaveTextContent('...');
+
+    if (defaultProps.children.length >= defaultProps.maxLength) {
+      expect(truncatedText).toHaveTextContent('...');
+    } else {
+      expect(truncatedText).not.toHaveTextContent('...');
+    }
   });
 
   it('renders the full text when expanded', () => {
     render(<Truncate {...defaultProps} />);
 
-    const button = screen.getByRole('button');
-    fireEvent.click(button);
+    if (defaultProps.children.length >= defaultProps.maxLength) {
+      const button = screen.getByRole('button');
+      fireEvent.click(button);
+    }
 
     const fullText = screen.getByText(defaultProps.children);
     expect(fullText).toBeInTheDocument();
@@ -37,9 +43,14 @@ describe('Truncate Component', () => {
   });
 
   it('renders custom ellipsis if provided', () => {
-    render(<Truncate {...defaultProps} ellipsis="***" />);
-
+    const ellipsis = '***' as const;
+    render(<Truncate {...defaultProps} ellipsis={ellipsis} />);
     const truncatedText = screen.getByText(/This is a long text/);
-    expect(truncatedText).toHaveTextContent('***');
+
+    if (defaultProps.children.length >= defaultProps.maxLength) {
+      expect(truncatedText).toHaveTextContent(ellipsis);
+    } else {
+      expect(truncatedText).not.toHaveTextContent(ellipsis);
+    }
   });
 });

--- a/libs/react-components/src/tedi/components/truncate/truncate.stories.tsx
+++ b/libs/react-components/src/tedi/components/truncate/truncate.stories.tsx
@@ -45,3 +45,11 @@ export const Default: Story = {
     expandable: true,
   },
 };
+
+export const NoTruncate: Story = {
+  render: TemplateColumn,
+  args: {
+    children: 'This text does not get truncated, because the length is smaller than maxLength property.',
+    maxLength: 100,
+  },
+};

--- a/libs/react-components/src/tedi/components/truncate/truncate.tsx
+++ b/libs/react-components/src/tedi/components/truncate/truncate.tsx
@@ -60,8 +60,8 @@ export const Truncate = (props: TruncateProps): JSX.Element => {
 
   return (
     <Text element="span" color="secondary" className={className}>
-      {isTruncated ? truncatedText : children}
-      {expandable && (
+      {children.length >= maxLength && isTruncated ? truncatedText : children}
+      {children.length >= maxLength && expandable && (
         <Button
           style={{ display: isTruncated ? undefined : 'block' }}
           visualType="link"


### PR DESCRIPTION
Fixed truncate button, now it is not showing when truncate text length is smaller than maxLength property.
Added story with this example to storybook.
Changed tests.