### PR TITLE
fix(collapse): prevent icon rotation in nested collapses #422

### DIFF
--- a/libs/react-components/src/community/components/collapse/collapse.module.scss
+++ b/libs/react-components/src/community/components/collapse/collapse.module.scss
@@ -12,7 +12,7 @@
   color: var(--color-primary-main);
   transition: transform 0.3s ease-in-out;
 
-  .collapse--is-open & {
+  .collapse--is-open > .collapse__title & {
     transform: rotate(180deg);
   }
 }

--- a/libs/react-components/src/community/components/collapse/collapse.tsx
+++ b/libs/react-components/src/community/components/collapse/collapse.tsx
@@ -96,11 +96,7 @@ export const Collapse = (props: CollapseProps): JSX.Element => {
     }
   };
 
-  const renderContent = (
-    <div className={styles['collapse__content']} data-name="collapse-content">
-      {children}
-    </div>
-  );
+  const renderContent = <div className={styles['collapse__content']}>{children}</div>;
 
   return (
     <div data-name="collapse" {...rest} className={BEM}>
@@ -115,7 +111,7 @@ export const Collapse = (props: CollapseProps): JSX.Element => {
       >
         <Row justifyContent="between" alignItems="center" wrap="nowrap" {...titleRowProps} element="span">
           {title && <Col>{title}</Col>}
-          <Col width="auto" className="collapse__col--icon">
+          <Col width="auto">
             <Row element="span" alignItems="center" gutter={1}>
               <Print visibility="hide">
                 <Col

--- a/libs/react-components/src/community/components/collapse/collapse.tsx
+++ b/libs/react-components/src/community/components/collapse/collapse.tsx
@@ -96,7 +96,11 @@ export const Collapse = (props: CollapseProps): JSX.Element => {
     }
   };
 
-  const renderContent = <div className={styles['collapse__content']}>{children}</div>;
+  const renderContent = (
+    <div className={styles['collapse__content']} data-name="collapse-content">
+      {children}
+    </div>
+  );
 
   return (
     <div data-name="collapse" {...rest} className={BEM}>
@@ -111,7 +115,7 @@ export const Collapse = (props: CollapseProps): JSX.Element => {
       >
         <Row justifyContent="between" alignItems="center" wrap="nowrap" {...titleRowProps} element="span">
           {title && <Col>{title}</Col>}
-          <Col width="auto">
+          <Col width="auto" className="collapse__col--icon">
             <Row element="span" alignItems="center" gutter={1}>
               <Print visibility="hide">
                 <Col


### PR DESCRIPTION
- Fix icon rotation inheritance in nested collapse components
- Update selector specificity to only target direct child collapse titles
- Add `data-name="collapse-content" for better` identification
- Add `className="collapse__col--icon"` for icon column styling
- Resolves unintended icon rotations in multilevel menu structures

https://iljakumlander.github.io/tedi-design-system/fix/424-collapse-inside-collapse/react/?path=/docs/community-collapse--docs