### PR TITLE
feat(header): add public header custom content support #441

### DIFF
--- a/libs/react-components/src/community/components/layout/header/header.stories.tsx
+++ b/libs/react-components/src/community/components/layout/header/header.stories.tsx
@@ -77,6 +77,34 @@ export const Public: Story = {
   },
 };
 
+/**
+ * Public header with custom content. Public header depends on LayoutContext to determine if the header is `public`. To see how public header works, please check the `Layout` component examples.
+ */
+export const PublicWithCustomContent: Story = {
+  render: Template,
+  args: {
+    ...Public.args,
+    enablePublicCustomContent: true,
+    children: (
+      <>
+        <HeaderSettings {...(HeaderSettingsDefault.args as HeaderSettingsProps)} />
+        <HeaderLanguage {...(HeaderLanguageDefault.args as HeaderLanguageProps)} />
+        <HeaderContent>
+          <StretchContent>
+            <Row justifyContent="center" alignItems="center">
+              <Col width="auto">Custom content</Col>
+            </Row>
+          </StretchContent>
+        </HeaderContent>
+      </>
+    ),
+  },
+
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
 export const HeaderWithNotification: Story = {
   render: Template,
   args: {

--- a/libs/react-components/src/community/components/layout/header/header/header.tsx
+++ b/libs/react-components/src/community/components/layout/header/header/header.tsx
@@ -48,11 +48,21 @@ export interface HeaderProps<H extends React.ElementType> {
    */
   minimalSettingsArea?: Layouts;
   /**
+   * @deprecated Use showCustomContent instead
+   */
+  showSystemCustomContent?: Layouts;
+  /**
    * In which breakpoints header should render custom content.
    * That means in those breakpoints only HeaderContent children is rendered.
    * @default ['desktop', 'tablet']
    */
-  showSystemCustomContent?: Layouts;
+  showCustomContent?: Layouts;
+  /**
+   * Whether the header should render public custom content.
+   * Only affects public header type.
+   * @default false
+   */
+  enablePublicCustomContent?: boolean;
   /**
    * Props of notification bar above the header.
    */
@@ -67,10 +77,14 @@ export const Header = <H extends React.ElementType = 'a'>(props: HeaderProps<H>)
     bottomContent,
     notification,
     minimalSettingsArea = ['mobile'],
-    showSystemCustomContent = ['desktop', 'tablet'],
+    showCustomContent,
+    showSystemCustomContent,
+    enablePublicCustomContent = false,
     ...rest
   } = props;
-  const renderSystemCustomContent = useLayout(showSystemCustomContent);
+  // Use showSystemCustomContent as fallback if showCustomContent is not provided
+  const effectiveCustomContent = showCustomContent ?? showSystemCustomContent ?? ['desktop', 'tablet'];
+  const renderCustomContent = useLayout(effectiveCustomContent);
   const renderMinimalSettingsArea = useLayout(minimalSettingsArea);
   const { headerType, sideNavProps, headerElement } = React.useContext(LayoutContext);
   const { shouldBreakToBottomContent, shouldBreakToHeader } = useSidenavRendered(headerType, sideNavProps);
@@ -145,8 +159,8 @@ export const Header = <H extends React.ElementType = 'a'>(props: HeaderProps<H>)
         <Logo {...logo} />
         <div className={styles['header__content']}>
           <div className={styles['header__content-left']}>
-            {headerType === 'system' &&
-              renderSystemCustomContent &&
+            {(headerType === 'system' || (enablePublicCustomContent && !shouldBreakToHeader)) &&
+              renderCustomContent &&
               filterHeaderDirectChildren(children, ContentAreaComponentOrder)}
             {shouldBreakToHeader && <HeaderNavigation />}
           </div>

--- a/libs/react-components/src/community/components/layout/header/headerDocumentation.mdx
+++ b/libs/react-components/src/community/components/layout/header/headerDocumentation.mdx
@@ -5,8 +5,8 @@ import { Meta } from '@storybook/blocks';
 # Header overview
 
 Currently we support two main header types: `public` and `system`.
-Public header is used for public (landing)pages and system header is used for pages that require authentication.
-Both headers are using the same markup and styling, but system header has additional functionality like user menu, notifications, custom content etc. <br/>
+Public header is used for public (landing) pages and system header is used for pages that require authentication.
+Both headers are using the same markup and styling, but system header has additional functionality like user menu, notifications etc. <br/>
 
 ## Header areas
 
@@ -81,7 +81,8 @@ It can be used to provide users with a way to navigate to different pages, searc
 HeaderContent can take all the remaining space of other Header areas (Settings & Logo), so it can be aligned every way Grid supports it. <br />
 **Note:** Use HeaderContent by passing it as direct children of Header. <br />
 **Note-2:** Order of Header children does not count, Header orders and filters children in itself. <br />
-**Note-3:** Bear in mind that HeaderContent is not rendered in every breakpoint. By deafult it's not rendered in mobile breakpoints. Those breakpoints can be customized by passing other valeue to `showSystemCustomContent`property in Header.
+**Note-3:** Bear in mind that HeaderContent is not rendered in every breakpoint. By default it's not rendered in mobile breakpoints. Those breakpoints can be customized by passing other value to `showCustomContent` property in Header (previously known as `showSystemCustomContent`).
+**Note-4:** Public HeaderContent is not rendered when `Header.enablePublicCustomContent` is false (default).
 And application should handle passing same functionality to HeaderSettings in mobile breakpoints. Look Layout examples to inspiration. <br />
 
 ### HeaderLanguage

--- a/libs/react-components/src/community/components/layout/layout/layout.stories.tsx
+++ b/libs/react-components/src/community/components/layout/layout/layout.stories.tsx
@@ -16,6 +16,7 @@ import {
   BottomContent as HeaderBottomContent,
   Default as HeaderDefault,
   Public as HeaderPublic,
+  PublicWithCustomContent as HeaderPublicWithCustomContent,
 } from '../header/header.stories';
 import SideNav, { SideNavProps } from '../sidenav/sidenav';
 import { Default as SidenavDefault, Public as SidenavPublic } from '../sidenav/sidenav.stories';
@@ -117,6 +118,20 @@ export const Public: Story = {
     sideNav: SidenavPublic.args as SideNavProps,
     headerType: 'public',
     breadcrumbsProps: undefined,
+  },
+};
+
+/**
+ * Layout with a public header and custom content enabled: `Header.enablePublicCustomContent` set to true (default false).
+ * It would render navigation to `Header` on larger screens based on breakpoints in `SideNav.breakToHeader` prop.
+ * <br/>
+ * When `SideNav.breakToHeader` breakpoint is met, custom content is not rendered.
+ */
+export const PublicWithCustomContent: Story = {
+  render: Template,
+  args: {
+    ...Public.args,
+    header: HeaderPublicWithCustomContent.args as HeaderProps<'a'>,
   },
 };
 

--- a/libs/react-components/src/community/components/layout/layout/layout.stories.tsx
+++ b/libs/react-components/src/community/components/layout/layout/layout.stories.tsx
@@ -103,7 +103,9 @@ export const Default: Story = {
 };
 
 /**
- * Layout with a public header. Public header is simpler, it does not support custom content to header, instead it renders navigation to Header on larger screens from Sidenav props.<br/>
+ * Layout with a public header. Public header is simpler, it supports custom content when `Header.enablePublicCustomContent` is true (default false).
+ * It would render navigation to `Header` on larger screens based on breakpoints in `SideNav.breakToHeader` prop. When `SideNav.breakToHeader` breakpoint is met, custom content is not rendered.
+ * <br/>
  * It can be used for public pages.
  */
 export const Public: Story = {


### PR DESCRIPTION
- Add new `enablePublicCustomContent` prop (default: `false`)
- Deprecate `showSystemCustomContent` in favor of `showCustomContent`
- Update documentation for public header content support and prop changes

https://iljakumlander.github.io/tedi-design-system/feat/441-custom-content-support-for-public-header/react/?path=/docs/community-layout--docs