### PR TITLE
fix(sidenav): design tweaks #526

### DIFF
--- a/libs/react-components/src/community/components/layout/sidenav/sidenav.module.scss
+++ b/libs/react-components/src/community/components/layout/sidenav/sidenav.module.scss
@@ -112,7 +112,7 @@
   --global-outline-color: var(--color-primary-active);
 
   .sidenav--hide-subitem-icons & {
-    [data-name='icon'] {
+    .sidenav__link [data-name='icon'] {
       display: none;
     }
   }

--- a/libs/react-components/src/community/components/layout/sidenav/sidenav.module.scss
+++ b/libs/react-components/src/community/components/layout/sidenav/sidenav.module.scss
@@ -111,6 +111,12 @@
 .sidenav__item .sidenav__item {
   --global-outline-color: var(--color-primary-active);
 
+  .sidenav--hide-subitem-icons & {
+    [data-name='icon'] {
+      display: none;
+    }
+  }
+
   [data-name='collapse-trigger'] {
     span.sidenav__link,
     [data-name='icon'] {
@@ -154,11 +160,19 @@ a.sidenav__link {
     & .sidenav__title:first-child {
       margin-left: calc(24px + 1rem);
     }
+
+    .sidenav--hide-subitem-icons & .sidenav__title {
+      margin-left: calc(14px + 1rem);
+    }
   }
 
   .sidenav__item .sidenav__item .sidenav__item & {
     & .sidenav__title:first-child {
       margin-left: calc(44px + 1rem);
+    }
+
+    .sidenav--hide-subitem-icons & .sidenav__title {
+      margin-left: calc(34px + 1rem);
     }
 
     & [data-name='icon']:first-child {

--- a/libs/react-components/src/community/components/layout/sidenav/sidenav.module.scss
+++ b/libs/react-components/src/community/components/layout/sidenav/sidenav.module.scss
@@ -120,7 +120,7 @@
     &[aria-expanded='true'],
     &:hover,
     &.sidenav__item--current {
-      background-color: var(--color-primary-active);
+      background-color: var(--color-primary-active-subtle);
 
       span.sidenav__link,
       [data-name='icon'] {
@@ -181,10 +181,14 @@ a.sidenav__link {
 
     &:hover {
       color: var(--color-text-inverted);
+      background-color: var(--color-primary-active-subtle);
     }
   }
 
   .sidenav__item .sidenav__item.sidenav__item--current > & {
     color: var(--color-text-inverted);
+    background-color: var(--color-primary-active-subtle);
+
+    --global-outline-color: var(--color-primary-highlight);
   }
 }

--- a/libs/react-components/src/community/components/layout/sidenav/sidenav.tsx
+++ b/libs/react-components/src/community/components/layout/sidenav/sidenav.tsx
@@ -55,6 +55,11 @@ export type SideNavProps<C extends React.ElementType = 'a'> = ConditionalTypes<C
    */
   showDividers?: boolean;
   /**
+   * Hide submenu icons
+   * @default false
+   */
+  hideSubItemIcons?: boolean;
+  /**
    * Additional class names for the sidenav component
    */
   className?: string;
@@ -79,6 +84,7 @@ export function SideNav<C extends React.ElementType = 'a'>(props: SideNavProps<C
     breakToBottomContent,
     breakToHeader,
     showDividers = true,
+    hideSubItemIcons = false,
     className,
     ...rest
   } = props;
@@ -93,6 +99,7 @@ export function SideNav<C extends React.ElementType = 'a'>(props: SideNavProps<C
 
   const BEM = cn(styles['sidenav'], className, {
     [styles['sidenav--has-dividers']]: showDividers,
+    [styles['sidenav--hide-subitem-icons']]: hideSubItemIcons,
   });
 
   const renderSidebar = (


### PR DESCRIPTION
- Fix submenu item color styling
- Add `hideSubItemIcons` prop (default: `false`) to optionally hide icons in submenu items

https://iljakumlander.github.io/tedi-design-system/fix/526-sidenav-design-tweaks/react/?path=/story/community-layout-sidenav--collapsible