### PR TITLE
feat(button,link): Add ability to display flexed Icons for Link, fix long text in Button #463

### DIFF
--- a/libs/react-components/src/community/components/anchor/anchor.stories.tsx
+++ b/libs/react-components/src/community/components/anchor/anchor.stories.tsx
@@ -172,7 +172,7 @@ export const NoStyleAnchor: Story = {
   args: {
     noStyle: true,
     href: 'https://www.neti.ee/',
-    children: <img src="https://www.neti.ee/img/neti-logo-2015-1.png" alt="neti.ee" />,
+    children: <img width={200} src="tehik_logo.png" alt="tehik.ee" />,
     target: '_blank',
   },
 };
@@ -189,10 +189,40 @@ export const FullWidth: Story = {
 /**
  * When link text wraps to multiple lines, the icon should be inline with the text.
  */
-export const LongText: Story = {
+export const LongTextIconInline: Story = {
   args: {
-    href: '#',
-    iconRight: 'north_east',
-    children: 'This is a very long link text that should wrap to multiple lines',
+    children: 'This is a very long link text that should wrap into multiple lines',
   },
+
+  render: (args) => (
+    <Row>
+      <Col md={4}>
+        <Anchor iconLeft="notifications">{args.children}</Anchor>
+      </Col>
+      <Col md={4}>
+        <Anchor iconRight="north_east">{args.children}</Anchor>
+      </Col>
+    </Row>
+  ),
+};
+
+export const LinkIconFlexed: Story = {
+  args: {
+    children: 'This is a very long link text that should wrap into multiple lines',
+  },
+
+  render: (args) => (
+    <Row>
+      <Col md={4}>
+        <Anchor iconLeft="notifications" iconStandalone>
+          {args.children}
+        </Anchor>
+      </Col>
+      <Col md={4}>
+        <Anchor iconRight="north_east" iconStandalone>
+          {args.children}
+        </Anchor>
+      </Col>
+    </Row>
+  ),
 };

--- a/libs/react-components/src/community/components/anchor/anchor.tsx
+++ b/libs/react-components/src/community/components/anchor/anchor.tsx
@@ -1,12 +1,17 @@
+import cn from 'classnames';
 import React, { forwardRef } from 'react';
 
 import { useLabels } from '../../../tedi/providers/label-provider';
 import { PolymorphicRef } from '../../helpers/polymorphic/types';
 import { IntentionalAny } from '../../types';
 import ButtonContent, { ButtonContentProps } from '../button-content/button-content';
+import styles from '../button-content/button-content.module.scss';
 
 export type InternalAnchorProps = {
-  // custom Anchor specific props
+  /**
+   * If true, the icon will be placed in a separate column
+   */
+  iconStandalone?: boolean;
 };
 
 type AllowedTags = 'a' | React.ComponentType<IntentionalAny>;
@@ -17,7 +22,7 @@ export type AnchorComponent = <C extends React.ElementType = 'a'>(props: AnchorP
 const InternalAnchor = forwardRef(
   <C extends React.ElementType = 'a'>(props: AnchorProps<C>, ref?: PolymorphicRef<C>) => {
     const { getLabel } = useLabels();
-    const { visualType = 'link', as, children, ...rest } = props;
+    const { visualType = 'link', as, iconStandalone = false, children, ...rest } = props;
 
     const ComponentAs = as || 'a';
 
@@ -28,6 +33,7 @@ const InternalAnchor = forwardRef(
         ref={ref}
         as={ComponentAs}
         visualType={visualType}
+        className={cn(rest.className, { [styles['btn__icon-standalone--link']]: iconStandalone })}
       >
         {children}
         {rest.target === '_blank' && <span className="sr-only">({getLabel('anchor.new-tab')})</span>}

--- a/libs/react-components/src/community/components/button-content/button-content.module.scss
+++ b/libs/react-components/src/community/components/button-content/button-content.module.scss
@@ -289,6 +289,7 @@ $btn-height-small: 2.25rem;
   display: inline-block;
   width: auto;
   height: auto;
+  min-height: auto;
   padding: 0;
   color: var(--color-primary-main);
   text-align: left;

--- a/libs/react-components/src/community/components/button-content/button-content.module.scss
+++ b/libs/react-components/src/community/components/button-content/button-content.module.scss
@@ -315,7 +315,7 @@ $btn-height-small: 2.25rem;
     color: var(--color-transparent);
   }
 
-  &:not(.tedi-btn--link .tedi-btn__text) {
+  &:not(.btn--link .btn__text) {
     text-wrap: nowrap;
 
     @include breakpoints.media-breakpoint-up(md) {

--- a/libs/react-components/src/community/components/button-content/button-content.module.scss
+++ b/libs/react-components/src/community/components/button-content/button-content.module.scss
@@ -1,4 +1,5 @@
 @use '@tehik-ee/tedi-core/mixins';
+@use '@tehik-ee/tedi-core/bootstrap-utility/breakpoints';
 
 $btn-height: 2.5rem;
 $btn-height-small: 2.25rem;
@@ -313,14 +314,19 @@ $btn-height-small: 2.25rem;
     color: var(--color-transparent);
   }
 
-  &:not(.btn--link .btn__text) {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    word-break: break-word;
+  &:not(.tedi-btn--link .tedi-btn__text) {
+    text-wrap: nowrap;
+
+    @include breakpoints.media-breakpoint-up(md) {
+      display: -webkit-box;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-wrap: wrap;
+      word-break: break-word;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
   }
 }
 

--- a/libs/react-components/src/community/components/button-content/button-content.module.scss
+++ b/libs/react-components/src/community/components/button-content/button-content.module.scss
@@ -77,7 +77,7 @@ $btn-height-small: 2.25rem;
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  height: $btn-height;
+  min-height: $btn-height;
   padding: 0 1.625rem; // 0 26px
   margin: 0;
   font-family: Roboto, Arial, Helvetica, sans-serif;
@@ -101,7 +101,7 @@ $btn-height-small: 2.25rem;
 }
 
 .btn--small {
-  height: $btn-height-small;
+  min-height: $btn-height-small;
   padding: 0 1.125rem; // 0 18px
   font-size: 0.875rem; // 14px
   line-height: 1.5rem; // 20px
@@ -300,7 +300,7 @@ $btn-height-small: 2.25rem;
 }
 
 .btn__text {
-  text-align: start;
+  text-align: center;
 
   .btn--link.btn--is-hovered:not(:disabled) &,
   .btn--link.btn--is-active:not(:disabled) &,
@@ -311,6 +311,16 @@ $btn-height-small: 2.25rem;
 
   .btn--is-loading:not(.btn--icon) & {
     color: var(--color-transparent);
+  }
+
+  &:not(.btn--link .btn__text) {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
   }
 }
 
@@ -323,6 +333,19 @@ $btn-height-small: 2.25rem;
 
   .btn--link:not(.btn--is-loading) & {
     display: inline;
+  }
+
+  .btn--link.btn__icon-standalone--link:not(.btn--is-loading) & {
+    display: inline-flex;
+    align-items: start;
+
+    .btn__icon {
+      @include mixins.responsive-styles(line-height, body-regular-line-height);
+    }
+
+    .btn__text {
+      text-align: left;
+    }
   }
 }
 

--- a/libs/react-components/src/community/components/button/button.stories.tsx
+++ b/libs/react-components/src/community/components/button/button.stories.tsx
@@ -223,3 +223,23 @@ export const FullWidth: Story = {
     children: 'Button that stretches',
   },
 };
+
+export const LongTextButtonThatWrapsIntoMultipleLines: Story = {
+  args: {
+    children: 'This is a very long link text that should wrap into multiple lines',
+  },
+
+  render: (args) => (
+    <Row>
+      <Col md={4}>
+        <Button>{args.children}</Button>
+      </Col>
+      <Col md={4}>
+        <Button iconLeft="edit">{args.children}</Button>
+      </Col>
+      <Col md={3}>
+        <Button>{args.children}</Button>
+      </Col>
+    </Row>
+  ),
+};

--- a/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
+++ b/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
@@ -163,7 +163,7 @@ $btn-width-large: 3.72rem;
 }
 
 .tedi-btn--large {
-  min-height: $btn-height-large;
+  height: $btn-height-large;
 
   @include mixins.responsive-styles(padding-top, button-md-padding-y, null, '- 1px');
   @include mixins.responsive-styles(padding-bottom, button-md-padding-y, null, '- 1px');

--- a/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
+++ b/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
@@ -119,7 +119,7 @@ $btn-width-large: 3.72rem;
   align-items: center;
   justify-content: center;
   max-width: 100%;
-  height: $btn-height;
+  min-height: $btn-height;
   margin: 0;
   text-align: center;
   text-decoration: none;
@@ -146,7 +146,7 @@ $btn-width-large: 3.72rem;
 }
 
 .tedi-btn--small {
-  height: $btn-height-small;
+  min-height: $btn-height-small;
 
   @include mixins.responsive-styles(font-size, button-text-size-sm);
   @include mixins.responsive-styles(padding-top, button-sm-padding-y);
@@ -160,7 +160,7 @@ $btn-width-large: 3.72rem;
 }
 
 .tedi-btn--large {
-  height: $btn-height-large;
+  min-height: $btn-height-large;
 
   @include mixins.responsive-styles(padding-top, button-md-padding-y);
   @include mixins.responsive-styles(padding-bottom, button-md-padding-y);
@@ -421,8 +421,6 @@ $btn-width-large: 3.72rem;
 }
 
 .tedi-btn__text {
-  text-align: start;
-
   @include mixins.responsive-styles(padding-left, button-md-inner-spacing);
   @include mixins.responsive-styles(padding-right, button-md-inner-spacing);
 
@@ -447,7 +445,13 @@ $btn-width-large: 3.72rem;
   }
 
   &:not(.tedi-btn--link .tedi-btn__text) {
-    text-wrap: nowrap;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word;
   }
 }
 
@@ -471,9 +475,17 @@ $btn-width-large: 3.72rem;
 .tedi-btn__inner {
   display: flex;
   align-items: center;
-  justify-content: center;
   min-width: 1.5rem;
   min-height: 1.5rem;
+
+  .tedi-btn--link.tedi-btn__icon-standalone--link:not(.tedi-btn--is-loading) & {
+    display: inline-flex;
+    align-items: start;
+
+    .tedi-btn__icon {
+      @include mixins.responsive-styles(line-height, body-regular-line-height);
+    }
+  }
 
   .tedi-btn--link:not(.tedi-btn--is-loading) & {
     display: inline;

--- a/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
+++ b/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
@@ -1,4 +1,5 @@
 @use '@tehik-ee/tedi-core/mixins';
+@use '@tehik-ee/tedi-core/bootstrap-utility/breakpoints';
 
 $btn-height: 2.5rem;
 $btn-height-small: 2rem;
@@ -133,8 +134,10 @@ $btn-width-large: 3.72rem;
   @include mixins.print-grayscale;
   @include mixins.responsive-styles(font-family, family-primary, $exclude: tablet);
   @include mixins.responsive-styles(font-size, button-text-size-default);
-  @include mixins.responsive-styles(padding-top, button-md-padding-y);
-  @include mixins.responsive-styles(padding-bottom, button-md-padding-y);
+
+  // subtract border height
+  @include mixins.responsive-styles(padding-top, button-md-padding-y, null, '- 1px');
+  @include mixins.responsive-styles(padding-bottom, button-md-padding-y, null, '- 1px');
   @include mixins.responsive-styles(padding-left, button-md-padding-x);
   @include mixins.responsive-styles(padding-right, button-md-padding-x);
   @include mixins.responsive-styles(border-radius, button-radius-default);
@@ -149,8 +152,8 @@ $btn-width-large: 3.72rem;
   min-height: $btn-height-small;
 
   @include mixins.responsive-styles(font-size, button-text-size-sm);
-  @include mixins.responsive-styles(padding-top, button-sm-padding-y);
-  @include mixins.responsive-styles(padding-bottom, button-sm-padding-y);
+  @include mixins.responsive-styles(padding-top, button-sm-padding-y, null, '- 1px');
+  @include mixins.responsive-styles(padding-bottom, button-sm-padding-y, null, '- 1px');
   @include mixins.responsive-styles(padding-left, button-sm-padding-x);
   @include mixins.responsive-styles(padding-right, button-sm-padding-x);
 
@@ -162,8 +165,8 @@ $btn-width-large: 3.72rem;
 .tedi-btn--large {
   min-height: $btn-height-large;
 
-  @include mixins.responsive-styles(padding-top, button-md-padding-y);
-  @include mixins.responsive-styles(padding-bottom, button-md-padding-y);
+  @include mixins.responsive-styles(padding-top, button-md-padding-y, null, '- 1px');
+  @include mixins.responsive-styles(padding-bottom, button-md-padding-y, null, '- 1px');
   @include mixins.responsive-styles(padding-left, button-md-padding-x);
   @include mixins.responsive-styles(padding-right, button-md-padding-x);
 
@@ -176,8 +179,8 @@ $btn-width-large: 3.72rem;
   padding: 0;
   background-clip: padding-box;
 
-  @include mixins.responsive-styles(padding-top, button-md-neutral-padding-y);
-  @include mixins.responsive-styles(padding-bottom, button-md-neutral-padding-y);
+  @include mixins.responsive-styles(padding-top, button-md-neutral-padding-y, null, '- 1px');
+  @include mixins.responsive-styles(padding-bottom, button-md-neutral-padding-y, null, '- 1px');
 
   &.tedi-btn--default.tedi-btn--icon-only {
     &:hover:not(:disabled) {
@@ -445,13 +448,18 @@ $btn-width-large: 3.72rem;
   }
 
   &:not(.tedi-btn--link .tedi-btn__text) {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    word-break: break-word;
+    text-wrap: nowrap;
+
+    @include breakpoints.media-breakpoint-up(md) {
+      display: -webkit-box;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      text-wrap: wrap;
+      word-break: break-word;
+      -webkit-line-clamp: 2;
+      line-clamp: 2;
+      -webkit-box-orient: vertical;
+    }
   }
 }
 
@@ -475,6 +483,7 @@ $btn-width-large: 3.72rem;
 .tedi-btn__inner {
   display: flex;
   align-items: center;
+  justify-content: center;
   min-width: 1.5rem;
   min-height: 1.5rem;
 

--- a/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
+++ b/libs/react-components/src/tedi/components/buttons/button-content/button-content.module.scss
@@ -401,6 +401,7 @@ $btn-width-large: 3.72rem;
   display: inline-flex;
   width: auto;
   height: auto;
+  min-height: auto;
   padding: 0;
   text-align: left;
   text-decoration: none;

--- a/libs/react-components/src/tedi/components/buttons/button/button.stories.tsx
+++ b/libs/react-components/src/tedi/components/buttons/button/button.stories.tsx
@@ -358,7 +358,9 @@ export const LongTextButtonThatWrapsIntoMultipleLines: Story = {
     <VerticalSpacing>
       <Row>
         <Col md={6}>
-          <Alert type="warning">Please avoid long text. This is fallback for emergencies—use only with caution.</Alert>
+          <Alert type="warning">
+            Please avoid long text. This is fallback for emergencies — use only with caution.
+          </Alert>
         </Col>
       </Row>
       <Row>

--- a/libs/react-components/src/tedi/components/buttons/button/button.stories.tsx
+++ b/libs/react-components/src/tedi/components/buttons/button/button.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { ElementType } from 'react';
 
 import { Col, Row } from '../../grid';
+import Alert from '../../notifications/alert/alert';
 import { Text, TextProps } from '../../typography/text/text';
 import { VerticalSpacing } from '../../vertical-spacing';
 import { Button, ButtonProps } from './button';
@@ -354,16 +355,23 @@ export const LongTextButtonThatWrapsIntoMultipleLines: Story = {
   },
 
   render: (args) => (
-    <Row>
-      <Col md={4}>
-        <Button>{args.children}</Button>
-      </Col>
-      <Col md={4}>
-        <Button iconLeft="edit">{args.children}</Button>
-      </Col>
-      <Col md={3}>
-        <Button>{args.children}</Button>
-      </Col>
-    </Row>
+    <VerticalSpacing>
+      <Row>
+        <Col md={6}>
+          <Alert type="warning">Please avoid long text. This is fallback for emergencies—use only with caution.</Alert>
+        </Col>
+      </Row>
+      <Row>
+        <Col md={4} width={12}>
+          <Button>{args.children}</Button>
+        </Col>
+        <Col md={4} width={12}>
+          <Button iconLeft="edit">{args.children}</Button>
+        </Col>
+        <Col md={3} width={12}>
+          <Button>{args.children}</Button>
+        </Col>
+      </Row>
+    </VerticalSpacing>
   ),
 };

--- a/libs/react-components/src/tedi/components/buttons/button/button.stories.tsx
+++ b/libs/react-components/src/tedi/components/buttons/button/button.stories.tsx
@@ -347,3 +347,23 @@ export const ResponsiveButton: Story = {
     },
   },
 };
+
+export const LongTextButtonThatWrapsIntoMultipleLines: Story = {
+  args: {
+    children: 'This is a very long button text that should wrap into multiple lines',
+  },
+
+  render: (args) => (
+    <Row>
+      <Col md={4}>
+        <Button>{args.children}</Button>
+      </Col>
+      <Col md={4}>
+        <Button iconLeft="edit">{args.children}</Button>
+      </Col>
+      <Col md={3}>
+        <Button>{args.children}</Button>
+      </Col>
+    </Row>
+  ),
+};

--- a/libs/react-components/src/tedi/components/buttons/floating-button/floating-button.stories.tsx
+++ b/libs/react-components/src/tedi/components/buttons/floating-button/floating-button.stories.tsx
@@ -30,11 +30,13 @@ const TemplateColumn: StoryFn<TemplateMultipleProps> = (args) => {
   return (
     <Row style={{ gap: buttonProps.axis === 'vertical' ? 100 : 0 }}>
       {buttonSizeArray.map((size) => (
-        <Col key={size} md={6}>
-          <Col style={{ paddingBottom: 16 }}>
-            <Text modifiers="bold">{size}</Text>
-          </Col>
-          <Row style={{ gap: buttonProps.axis === 'vertical' ? 100 : 16 }}>
+        <Col key={size} md={12}>
+          <Row style={{ paddingBottom: 16 }}>
+            <Col md={12} lg={6}>
+              <Text modifiers="bold">{size}</Text>
+            </Col>
+          </Row>
+          <Row style={{ gap: buttonProps.axis === 'vertical' ? 100 : 16, paddingBottom: 16 }}>
             {array.map((value, key) => (
               <Col xs={12} key={key} style={{ display: buttonProps.axis === 'vertical' ? 'flex' : undefined }}>
                 <Col xs={2}>

--- a/libs/react-components/src/tedi/components/buttons/floating-button/floating-button.stories.tsx
+++ b/libs/react-components/src/tedi/components/buttons/floating-button/floating-button.stories.tsx
@@ -28,9 +28,9 @@ const TemplateColumn: StoryFn<TemplateMultipleProps> = (args) => {
   const { array, ...buttonProps } = args;
 
   return (
-    <Row style={{ gap: buttonProps.axis === 'vertical' ? 100 : 30 }}>
+    <Row style={{ gap: buttonProps.axis === 'vertical' ? 100 : 0 }}>
       {buttonSizeArray.map((size) => (
-        <Col key={size}>
+        <Col key={size} md={6}>
           <Col style={{ paddingBottom: 16 }}>
             <Text modifiers="bold">{size}</Text>
           </Col>

--- a/libs/react-components/src/tedi/components/buttons/info-button/info-button.module.scss
+++ b/libs/react-components/src/tedi/components/buttons/info-button/info-button.module.scss
@@ -6,4 +6,5 @@
 
   @include mixins.responsive-styles(width, button-xs-icon-size);
   @include mixins.responsive-styles(height, button-xs-icon-size);
+  @include mixins.responsive-styles(min-height, button-xs-icon-size);
 }

--- a/libs/react-components/src/tedi/components/form/number-field/number-field.tsx
+++ b/libs/react-components/src/tedi/components/form/number-field/number-field.tsx
@@ -186,6 +186,7 @@ export const NumberField = (props: NumberFieldProps) => {
         visualType="secondary"
         className={ButtonBEM}
         icon={{ name: direction === 'increment' ? 'add' : 'remove' }}
+        size={size === 'small' ? 'small' : undefined}
       >
         {direction === 'increment' ? '+' : '-'}
       </Button>

--- a/libs/react-components/src/tedi/components/form/search/search.module.scss
+++ b/libs/react-components/src/tedi/components/form/search/search.module.scss
@@ -23,6 +23,8 @@ $input-height-mobile: 2.75rem;
   }
 
   &__button {
+    flex: 0 auto;
+    min-width: fit-content;
     white-space: nowrap;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;

--- a/libs/react-components/src/tedi/components/navigation/link/link.spec.tsx
+++ b/libs/react-components/src/tedi/components/navigation/link/link.spec.tsx
@@ -64,4 +64,16 @@ describe('Link component', () => {
     fireEvent.click(link);
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it('applies correct class when iconStandalone is true', () => {
+    render(<Link {...defaultProps} iconStandalone />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('tedi-btn__icon-standalone--link');
+  });
+
+  it('does not apply iconStandalone class when iconStandalone is false', () => {
+    render(<Link {...defaultProps} iconStandalone={false} />);
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveClass('tedi-btn--link--icon-standalone');
+  });
 });

--- a/libs/react-components/src/tedi/components/navigation/link/link.stories.tsx
+++ b/libs/react-components/src/tedi/components/navigation/link/link.stories.tsx
@@ -26,6 +26,7 @@ const meta: Meta<typeof Link> = {
 };
 
 export default meta;
+type Story = StoryObj<typeof Link>;
 
 const linkStateArray = ['Default', 'Hover', 'Active'];
 const Template: StoryFn<LinkProps<ElementType>> = (args) => <Link href="#" {...args} />;
@@ -247,10 +248,40 @@ export const FullWidth = {
   },
 };
 
-export const LongText = {
+export const LongTextIconInline: Story = {
   args: {
-    href: '#',
-    iconRight: 'north_east',
     children: 'This is a very long link text that should wrap into multiple lines',
   },
+
+  render: (args) => (
+    <Row>
+      <Col md={4}>
+        <Link iconLeft="notifications">{args.children}</Link>
+      </Col>
+      <Col md={4}>
+        <Link iconRight="north_east">{args.children}</Link>
+      </Col>
+    </Row>
+  ),
+};
+
+export const LinkIconFlexed: Story = {
+  args: {
+    children: 'This is a very long link text that should wrap into multiple lines',
+  },
+
+  render: (args) => (
+    <Row>
+      <Col md={4}>
+        <Link iconLeft="notifications" iconStandalone>
+          {args.children}
+        </Link>
+      </Col>
+      <Col md={4}>
+        <Link iconRight="north_east" iconStandalone>
+          {args.children}
+        </Link>
+      </Col>
+    </Row>
+  ),
 };

--- a/libs/react-components/src/tedi/components/navigation/link/link.tsx
+++ b/libs/react-components/src/tedi/components/navigation/link/link.tsx
@@ -1,3 +1,4 @@
+import cn from 'classnames';
 import React, { forwardRef } from 'react';
 
 import { BreakpointSupport, useBreakpointProps } from '../../../helpers';
@@ -5,9 +6,13 @@ import { PolymorphicRef } from '../../../helpers/polymorphic/types';
 import { useLabels } from '../../../providers/label-provider';
 import { UnknownType } from '../../../types/commonTypes';
 import ButtonContent, { ButtonContentProps } from '../../buttons/button-content/button-content';
+import styles from '../../buttons/button-content/button-content.module.scss';
 
 export type InternalLinkProps = {
-  // custom Link specific props
+  /**
+   * If true, the icon will be placed in a separate column
+   */
+  iconStandalone?: boolean;
 };
 
 type AllowedTags = 'a' | React.ComponentType<UnknownType>;
@@ -28,6 +33,7 @@ const LinkComponent = forwardRef(<C extends React.ElementType = 'a'>(props: Link
 
   const {
     visualType = 'link',
+    iconStandalone = false,
     underline = true,
     as,
     children,
@@ -44,6 +50,7 @@ const LinkComponent = forwardRef(<C extends React.ElementType = 'a'>(props: Link
       as={ComponentAs}
       visualType={visualType}
       underline={underline}
+      className={cn(rest.className, { [styles['tedi-btn__icon-standalone--link']]: iconStandalone })}
     >
       {children}
       {rest.target === '_blank' && <span className="sr-only">({getLabel('anchor.new-tab')})</span>}


### PR DESCRIPTION
TEDI-Ready:
- Button: https://github.tehik.ee/tedi-design-system/fix/463-button-link-long-text-and-icons/react/?path=/docs/tedi-ready-components-buttons-button--docs
- Link: https://github.tehik.ee/tedi-design-system/fix/463-button-link-long-text-and-icons/react/?path=/docs/tedi-ready-components-navigation-link--docs

Community:
- Anchor: https://github.tehik.ee/tedi-design-system/fix/463-button-link-long-text-and-icons/react/?path=/docs/community-anchor--docs
- Button: https://github.tehik.ee/tedi-design-system/fix/463-button-link-long-text-and-icons/react/?path=/docs/community-button--docs