### PR TITLE
fix(icon): icon sizes to rems, icon loading layout shift fix #645 #647

### DIFF
--- a/libs/react-components/package-lock.json
+++ b/libs/react-components/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/material": "^5.15.13",
         "@mui/x-date-pickers": "^5.0.20",
         "@tanstack/react-table": "^8.13.2",
-        "@tehik-ee/tedi-core": "^1.8.2",
+        "@tehik-ee/tedi-core": "^1.10.1",
         "classnames": "^2.5.1",
         "dayjs": "^1.11.10",
         "draft-js": "^0.11.7",
@@ -6236,9 +6236,9 @@
       }
     },
     "node_modules/@tehik-ee/tedi-core": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@tehik-ee/tedi-core/-/tedi-core-1.8.2.tgz",
-      "integrity": "sha512-0ixwB9maJuQojpdMu1QUL77GBPK175230+0D4c6lHkg0tbPX5YmmCDkN7fVrJl7oD50bWuXZiNvgoI7zvAM+Fg=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@tehik-ee/tedi-core/-/tedi-core-1.10.1.tgz",
+      "integrity": "sha512-LhZsMMI1dsRSCSaBZ+l9Oe+GizCVJ0feJH+7uXibUPDRwBVc2ACRB1ef4ZbVzmkGK13jahP6wyTomgcNVs5FXw=="
     },
     "node_modules/@testing-library/dom": {
       "version": "9.3.4",

--- a/libs/react-components/package.json
+++ b/libs/react-components/package.json
@@ -35,7 +35,7 @@
     "@mui/material": "^5.15.13",
     "@mui/x-date-pickers": "^5.0.20",
     "@tanstack/react-table": "^8.13.2",
-    "@tehik-ee/tedi-core": "^1.8.2",
+    "@tehik-ee/tedi-core": "^1.10.1",
     "classnames": "^2.5.1",
     "dayjs": "^1.11.10",
     "draft-js": "^0.11.7",

--- a/libs/react-components/src/tedi/components/icon/icon.module.scss
+++ b/libs/react-components/src/tedi/components/icon/icon.module.scss
@@ -62,6 +62,9 @@ $icon-sizes: (
 }
 
 .tedi-icon {
+  max-width: 1em;
+  overflow: hidden;
+
   &.tedi-icon--block {
     display: block;
   }
@@ -80,9 +83,6 @@ $icon-sizes: (
 
   @each $size, $vars in $icon-sizes {
     &--size-#{$size} {
-      max-width: 1em;
-      overflow: hidden;
-
       @include mixins.responsive-styles(font-size, $vars);
     }
   }

--- a/libs/react-components/src/tedi/components/icon/icon.module.scss
+++ b/libs/react-components/src/tedi/components/icon/icon.module.scss
@@ -80,6 +80,9 @@ $icon-sizes: (
 
   @each $size, $vars in $icon-sizes {
     &--size-#{$size} {
+      max-width: 1em;
+      overflow: hidden;
+
       @include mixins.responsive-styles(font-size, $vars);
     }
   }


### PR DESCRIPTION
Dimensions px -> rem in this commit:
https://github.com/TEHIK-EE/tedi-design-system/commit/d06ffd15b99f476a3ec51e48e02258714c5ddd83