### PR TITLE
fix(useBreakpointProps): remove window usage in SSR, add defaultServerBreakpoint #786

### DIFF
--- a/libs/react-components/src/community/components/card/card-content/card-content.tsx
+++ b/libs/react-components/src/community/components/card/card-content/card-content.tsx
@@ -48,7 +48,7 @@ export interface CardContentProps extends BreakpointSupport<CardContentBreakpoin
 
 export const CardContent = (props: CardContentProps): JSX.Element => {
   const { padding: rootPadding, background: rootBackground } = React.useContext(CardContext);
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
 
   const { children, className, padding, background, ...rest } = getCurrentBreakpointProps<CardContentProps>(props, {
     padding: rootPadding,

--- a/libs/react-components/src/community/components/card/card-header/card-header.tsx
+++ b/libs/react-components/src/community/components/card/card-header/card-header.tsx
@@ -50,7 +50,7 @@ export interface CardHeaderAsButton extends Partial<React.ButtonHTMLAttributes<H
 
 export const CardHeader = (props: CardHeaderProps): JSX.Element => {
   const { variant, ...restOfProps } = props;
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { padding: rootPadding } = React.useContext(CardContext);
   const { children, className, background, padding, ...rest } = getCurrentBreakpointProps<CardHeaderProps>(
     restOfProps,

--- a/libs/react-components/src/community/components/card/card.tsx
+++ b/libs/react-components/src/community/components/card/card.tsx
@@ -44,7 +44,7 @@ export interface CardProps extends BreakpointSupport<CardBreakpointProps> {
 }
 
 export const Card = forwardRef<HTMLDivElement, CardProps>((props, ref): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     className,

--- a/libs/react-components/src/community/components/tabs/tabs-item/tabs-item.tsx
+++ b/libs/react-components/src/community/components/tabs/tabs-item/tabs-item.tsx
@@ -26,7 +26,7 @@ export interface TabsItemProps extends BreakpointSupport<TabsItemBreakpointProps
 }
 
 export const TabsItem = (props: TabsItemProps) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { className, padding, background, id, children } = getCurrentBreakpointProps<TabsItemProps>(props, {
     padding: { top: 1.5, right: 2, bottom: 2, left: 2 },
     background: 'white',

--- a/libs/react-components/src/community/components/typography/text/text.tsx
+++ b/libs/react-components/src/community/components/typography/text/text.tsx
@@ -79,7 +79,7 @@ export interface TextProps extends BreakpointSupport<TextBreakpointProps> {
 }
 
 export const Text = (props: TextProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     className,

--- a/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.mdx
+++ b/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.mdx
@@ -29,7 +29,7 @@ interface ComponentProps extends BreakpointSupport<ComponentBreakpointProps> {
 }
 
 const Component = (props: ComponentProps) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { prop1, prop2, ...rest } = getCurrentBreakpointProps<ComponentProps>(props, defaultPropsObject);
 
   return <p>content</p>;
@@ -40,6 +40,24 @@ And when using as Component:
 
 ```tsx
 <Component background="bg-muted" sm={{ background: 'bg-primary' }} xl={{ background: 'bg-primary-highlight' }}>
+  <p>Content</p>
+</Component>
+```
+
+## defaultServerBreakpoint with SSR
+
+When using SSR, you can to pass the defaultServerBreakpoint prop to the component.
+This prop should be set to the breakpoint that is wanted to render on the server side.
+This is important when wanting to avoid large layout shifts with SSR.
+Defaults to 'xs' if not set.
+
+```tsx
+<Component
+  defaultServerBreakpoint="xl"
+  background="bg-muted"
+  sm={{ background: 'bg-primary' }}
+  xl={{ background: 'bg-primary-highlight' }}
+>
   <p>Content</p>
 </Component>
 ```

--- a/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.mdx
+++ b/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.mdx
@@ -46,7 +46,7 @@ And when using as Component:
 
 ## defaultServerBreakpoint with SSR
 
-When using SSR, you can to pass the defaultServerBreakpoint prop to the component.
+When using SSR, you can pass the defaultServerBreakpoint prop to the component.
 This prop should be set to the breakpoint that is wanted to render on the server side.
 This is important when wanting to avoid large layout shifts with SSR.
 Defaults to 'xs' if not set.

--- a/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.ts
+++ b/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.ts
@@ -39,7 +39,7 @@ export const useBreakpointProps = (defaultServerBreakpoint: Breakpoint = 'xs') =
  * BreakpointSupport is a utility type that allows you to define props for different breakpoints.
  * It extends the given type T and adds optional properties for each breakpoint except 'xs'.
  * This is useful for creating responsive components that can have different props based on the current breakpoint.
- * Also defaultSSRBreakpoint is added to the type, so you can set a default value for the component, when it's rendered on the server-side.
+ * Also defaultServerBreakpoint is added to the type, so you can set a default value for the component, when it's rendered on the server-side.
  * Because in SSR we don't have access to the window object and can't know the user's screen size.
  */
 export type BreakpointSupport<T> = T & {

--- a/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.ts
+++ b/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.ts
@@ -1,10 +1,10 @@
-import { pickBy } from 'lodash-es';
+import { omit, pickBy } from 'lodash-es';
 import React from 'react';
 
 import useBreakpoint, { Breakpoint, breakpoints } from './use-breakpoint';
 
-export const useBreakpointProps = () => {
-  const currentBreakpoint = useBreakpoint();
+export const useBreakpointProps = (defaultServerBreakpoint: Breakpoint = 'xs') => {
+  const currentBreakpoint = useBreakpoint(defaultServerBreakpoint);
   const activeBreakpoints: Breakpoint[] = React.useMemo(
     () => (currentBreakpoint ? breakpoints.slice(0, breakpoints.indexOf(currentBreakpoint) + 1) : []),
     [currentBreakpoint]
@@ -19,13 +19,15 @@ export const useBreakpointProps = () => {
     <T>(
       props: BreakpointSupport<T>,
       defaultValues: Partial<T> = {}
-    ): Omit<BreakpointSupport<T>, Exclude<Breakpoint, 'xs'>> => {
+    ): Omit<BreakpointSupport<T>, Exclude<Breakpoint, 'xs'> | 'defaultServerBreakpoint'> => {
       const { sm, md, lg, xl, xxl, ...xs } = props;
       const propArray = [
         ...activeBreakpoints.map((bp) => pickBy(bp === 'xs' ? xs : props[bp], (value) => value !== undefined)), // filter out props that have undefined as value, so they don't override lower breakpoint values or default values
       ].filter(Boolean);
 
-      return Object.assign(defaultValues, ...propArray);
+      // Add propArray to defaultValues
+      // and remove defaultServerBreakpoint from defaultValues - to avoided passing to HTML element with rest props
+      return Object.assign(omit(defaultValues, 'defaultServerBreakpoint'), ...propArray);
     },
     [activeBreakpoints]
   );
@@ -33,6 +35,18 @@ export const useBreakpointProps = () => {
   return { getCurrentBreakpointProps };
 };
 
+/**
+ * BreakpointSupport is a utility type that allows you to define props for different breakpoints.
+ * It extends the given type T and adds optional properties for each breakpoint except 'xs'.
+ * This is useful for creating responsive components that can have different props based on the current breakpoint.
+ * Also defaultSSRBreakpoint is added to the type, so you can set a default value for the component, when it's rendered on the server-side.
+ * Because in SSR we don't have access to the window object and can't know the user's screen size.
+ */
 export type BreakpointSupport<T> = T & {
+  /**
+   * Default breakpoint for SSR, the component is rendered with this breakpoint props on the server-side.
+   */
+  defaultServerBreakpoint?: Breakpoint;
+} & {
   [key in Exclude<Breakpoint, 'xs'>]?: Partial<T>;
 };

--- a/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.ts
+++ b/libs/react-components/src/community/helpers/hooks/use-breakpoint-props.ts
@@ -20,6 +20,7 @@ export const useBreakpointProps = (defaultServerBreakpoint: Breakpoint = 'xs') =
       props: BreakpointSupport<T>,
       defaultValues: Partial<T> = {}
     ): Omit<BreakpointSupport<T>, Exclude<Breakpoint, 'xs'> | 'defaultServerBreakpoint'> => {
+      // eslint-disable-next-line unused-imports/no-unused-vars
       const { sm, md, lg, xl, xxl, ...xs } = props;
       const propArray = [
         ...activeBreakpoints.map((bp) => pickBy(bp === 'xs' ? xs : props[bp], (value) => value !== undefined)), // filter out props that have undefined as value, so they don't override lower breakpoint values or default values

--- a/libs/react-components/src/community/helpers/hooks/use-breakpoint.ts
+++ b/libs/react-components/src/community/helpers/hooks/use-breakpoint.ts
@@ -1,16 +1,39 @@
-import debounce from 'lodash-es/debounce';
-import { useEffect, useState } from 'react';
+import { debounce } from 'lodash-es';
+import { useLayoutEffect, useState } from 'react';
 
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 export const breakpoints: Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'];
 
-export const useBreakpoint = (): Breakpoint | null => {
-  const [breakpoint, setBreakpoint] = useState(getBreakpoint());
+/**
+ * @param defaultServerBreakpoint - Default breakpoint for SSR, the hook returns this breakpoint in the SSR.
+ * @returns User's current breakpoint
+ */
+export const useBreakpoint = (defaultServerBreakpoint: Breakpoint = 'xs'): Breakpoint => {
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>(defaultServerBreakpoint);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const getBreakpoint = (): Breakpoint => {
+      if (window.matchMedia('(min-width: 1400px)').matches) {
+        return 'xxl';
+      } else if (window.matchMedia('(min-width: 1200px)').matches) {
+        return 'xl';
+      } else if (window.matchMedia('(min-width: 992px)').matches) {
+        return 'lg';
+      } else if (window.matchMedia('(min-width: 768px)').matches) {
+        return 'md';
+      } else if (window.matchMedia('(min-width: 576px)').matches) {
+        return 'sm';
+      } else {
+        return 'xs';
+      }
+    };
+
     const resizeEvent = debounce((): void => {
       setBreakpoint(getBreakpoint());
     }, 20);
+
+    // Set the initial breakpoint on the client
+    setBreakpoint(getBreakpoint());
 
     window.addEventListener('resize', resizeEvent);
     return () => {
@@ -18,28 +41,6 @@ export const useBreakpoint = (): Breakpoint | null => {
       window.removeEventListener('resize', resizeEvent);
     };
   }, []);
-
-  return breakpoint;
-};
-
-const getBreakpoint = (): Breakpoint | null => {
-  let breakpoint: Breakpoint | null = null;
-
-  if (typeof window !== 'undefined') {
-    if (window.matchMedia('(min-width: 1400px)').matches) {
-      breakpoint = 'xxl';
-    } else if (window.matchMedia('(min-width: 1200px)').matches) {
-      breakpoint = 'xl';
-    } else if (window.matchMedia('(min-width: 992px)').matches) {
-      breakpoint = 'lg';
-    } else if (window.matchMedia('(min-width: 768px)').matches) {
-      breakpoint = 'md';
-    } else if (window.matchMedia('(min-width: 576px)').matches) {
-      breakpoint = 'sm';
-    } else {
-      breakpoint = 'xs';
-    }
-  }
 
   return breakpoint;
 };

--- a/libs/react-components/src/tedi/components/base/typography/text/text.tsx
+++ b/libs/react-components/src/tedi/components/base/typography/text/text.tsx
@@ -86,7 +86,7 @@ const isHeadingModifier = (modifier: TextModifiers): modifier is HeadingModifier
 };
 
 export const Text = (props: TextProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     className,

--- a/libs/react-components/src/tedi/components/buttons/button/button.tsx
+++ b/libs/react-components/src/tedi/components/buttons/button/button.tsx
@@ -29,7 +29,7 @@ export type ButtonProps<C extends React.ElementType = 'button'> = BreakpointSupp
 
 const ButtonComponent = forwardRef(
   <C extends React.ElementType = 'button'>(props: ButtonProps<C>, ref?: PolymorphicRef<C>) => {
-    const { getCurrentBreakpointProps } = useBreakpointProps();
+    const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
 
     const {
       children,

--- a/libs/react-components/src/tedi/components/buttons/collapse/collapse.tsx
+++ b/libs/react-components/src/tedi/components/buttons/collapse/collapse.tsx
@@ -76,7 +76,7 @@ export interface CollapseProps extends BreakpointSupport<CollapseBreakpointProps
 }
 
 export const Collapse = (props: CollapseProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { getLabel } = useLabels();
   const {
     id,

--- a/libs/react-components/src/tedi/components/cards/card/card-content/card-content.tsx
+++ b/libs/react-components/src/tedi/components/cards/card/card-content/card-content.tsx
@@ -15,7 +15,7 @@ export interface CardContentProps extends BreakpointSupport<SharedCardProps> {
 
 export const CardContent = (props: CardContentProps): JSX.Element => {
   const { padding: rootPadding, background: rootBackground } = React.useContext(CardContext);
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
 
   const {
     children,

--- a/libs/react-components/src/tedi/components/cards/card/card.tsx
+++ b/libs/react-components/src/tedi/components/cards/card/card.tsx
@@ -83,7 +83,7 @@ export interface CardProps extends BreakpointSupport<CardBreakpointProps> {
 }
 
 const CardComponent = forwardRef<HTMLDivElement, CardProps>((props, ref): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { children, className, padding, background, borderRadius, borderless, border, ...rest } =
     getCurrentBreakpointProps<CardProps>(props, { padding: 1 });
 

--- a/libs/react-components/src/tedi/components/content/label/label.tsx
+++ b/libs/react-components/src/tedi/components/content/label/label.tsx
@@ -43,7 +43,7 @@ export interface LabelProps
 }
 
 export const Label = forwardRef<HTMLLabelElement | HTMLSpanElement, LabelProps>((props, ref) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     as: Element = 'label',
     children,

--- a/libs/react-components/src/tedi/components/content/list/list-item.tsx
+++ b/libs/react-components/src/tedi/components/content/list/list-item.tsx
@@ -24,7 +24,7 @@ export interface ListItemProps extends BreakpointSupport<ListItemBreakpointProps
 }
 
 export const ListItem = (props: ListItemProps) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { children, verticalSpacingItem, className } = getCurrentBreakpointProps<ListItemProps>(props);
   const listItemBEM = cn(styles['tedi-list__item'], verticalSpacingItem?.className, className);
 

--- a/libs/react-components/src/tedi/components/content/list/list.tsx
+++ b/libs/react-components/src/tedi/components/content/list/list.tsx
@@ -38,7 +38,7 @@ export interface ListProps extends BreakpointSupport<ListBreakpointProps> {
 }
 
 export const List = (props: ListProps) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     element = 'ul',

--- a/libs/react-components/src/tedi/components/content/text-group/text-group.tsx
+++ b/libs/react-components/src/tedi/components/content/text-group/text-group.tsx
@@ -35,7 +35,7 @@ export interface TextGroupProps extends BreakpointSupport<TextGroupBreakpointPro
 }
 
 export const TextGroup = (props: TextGroupProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     label,
     value,

--- a/libs/react-components/src/tedi/components/content/truncate/truncate.tsx
+++ b/libs/react-components/src/tedi/components/content/truncate/truncate.tsx
@@ -41,7 +41,7 @@ export interface TruncateProps extends BreakpointSupport<TruncateBreakpointProps
 }
 
 export const Truncate = (props: TruncateProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     className,

--- a/libs/react-components/src/tedi/components/form/choice-group/choice-group.tsx
+++ b/libs/react-components/src/tedi/components/form/choice-group/choice-group.tsx
@@ -46,8 +46,8 @@ export interface ChoiceGroupProps extends BreakpointSupport<ChoiceGroupAllProps>
 
 export const ChoiceGroup = (props: ChoiceGroupProps): React.ReactElement => {
   const { getLabel } = useLabels();
-  const currentBreakpoint = useBreakpoint();
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const currentBreakpoint = useBreakpoint(props.defaultServerBreakpoint);
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     id,
     className,

--- a/libs/react-components/src/tedi/components/form/choice-group/components/choice-group-item/choice-group-item.tsx
+++ b/libs/react-components/src/tedi/components/form/choice-group/components/choice-group-item/choice-group-item.tsx
@@ -35,7 +35,7 @@ export interface ExtendedChoiceGroupItemProps extends BreakpointSupport<ChoiceGr
 }
 
 export const ChoiceGroupItem = (props: ExtendedChoiceGroupItemProps): React.ReactElement => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     id,
     label,

--- a/libs/react-components/src/tedi/components/form/number-field/number-field.tsx
+++ b/libs/react-components/src/tedi/components/form/number-field/number-field.tsx
@@ -77,7 +77,7 @@ export interface NumberFieldProps extends BreakpointSupport<NumberFieldBreakpoin
 }
 
 export const NumberField = (props: NumberFieldProps) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     id,
     label,

--- a/libs/react-components/src/tedi/components/form/textfield/textfield.tsx
+++ b/libs/react-components/src/tedi/components/form/textfield/textfield.tsx
@@ -132,7 +132,7 @@ export interface TextFieldForwardRef {
 }
 
 export const TextField = forwardRef<TextFieldForwardRef, TextFieldProps>((props, ref): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     id,
     label,

--- a/libs/react-components/src/tedi/components/layout/vertical-spacing/vertical-spacing-item.tsx
+++ b/libs/react-components/src/tedi/components/layout/vertical-spacing/vertical-spacing-item.tsx
@@ -29,7 +29,7 @@ export interface VerticalSpacingItemProps extends BreakpointSupport<VerticalSpac
 }
 
 export const VerticalSpacingItem = (props: VerticalSpacingItemProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     className,

--- a/libs/react-components/src/tedi/components/layout/vertical-spacing/vertical-spacing.tsx
+++ b/libs/react-components/src/tedi/components/layout/vertical-spacing/vertical-spacing.tsx
@@ -32,7 +32,7 @@ export interface VerticalSpacingProps extends BreakpointSupport<VerticalSpacingB
 }
 
 export const VerticalSpacing = (props: VerticalSpacingProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     className,

--- a/libs/react-components/src/tedi/components/loaders/skeleton/skeleton-block/skeleton-block.tsx
+++ b/libs/react-components/src/tedi/components/loaders/skeleton/skeleton-block/skeleton-block.tsx
@@ -34,7 +34,7 @@ export interface SkeletonBlockProps extends BreakpointSupport<SkeletonBlockBreak
 }
 
 export const SkeletonBlock = (props: SkeletonBlockProps) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { width = 'auto', height = 'p', className, style } = getCurrentBreakpointProps<SkeletonBlockProps>(props);
   let widthStyle: string;
   if (typeof width === 'number') {

--- a/libs/react-components/src/tedi/components/loaders/spinner/spinner.tsx
+++ b/libs/react-components/src/tedi/components/loaders/spinner/spinner.tsx
@@ -43,7 +43,7 @@ export interface SpinnerProps extends BreakpointSupport<SpinnerBreakpointProps> 
 
 export const Spinner = (props: SpinnerProps): JSX.Element => {
   const { getLabel } = useLabels();
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
 
   const {
     className,

--- a/libs/react-components/src/tedi/components/misc/separator/separator.tsx
+++ b/libs/react-components/src/tedi/components/misc/separator/separator.tsx
@@ -109,7 +109,7 @@ export type SeparatorProps = BreakpointSupport<
   SeparatorBreakpointProps;
 
 export const Separator = (props: SeparatorProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     className,
     element: Element = 'div',

--- a/libs/react-components/src/tedi/components/misc/stretch-content/stretch-content.tsx
+++ b/libs/react-components/src/tedi/components/misc/stretch-content/stretch-content.tsx
@@ -35,7 +35,7 @@ export interface StretchContentProps extends BreakpointSupport<StretchContentBre
 }
 
 export const StretchContent = (props: StretchContentProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     role,

--- a/libs/react-components/src/tedi/components/navigation/link/link.tsx
+++ b/libs/react-components/src/tedi/components/navigation/link/link.tsx
@@ -28,7 +28,7 @@ export type LinkProps<C extends React.ElementType = 'a'> = BreakpointSupport<
 >;
 
 const LinkComponent = forwardRef(<C extends React.ElementType = 'a'>(props: LinkProps<C>, ref?: PolymorphicRef<C>) => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const { getLabel } = useLabels();
 
   const {

--- a/libs/react-components/src/tedi/components/notifications/alert/alert.tsx
+++ b/libs/react-components/src/tedi/components/notifications/alert/alert.tsx
@@ -71,7 +71,7 @@ export interface AlertProps extends BreakpointSupport<AlertBreakpointProps> {
 }
 
 export const Alert = (props: AlertProps): JSX.Element | null => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     role = 'alert',

--- a/libs/react-components/src/tedi/components/tags/status-badge/status-badge.tsx
+++ b/libs/react-components/src/tedi/components/tags/status-badge/status-badge.tsx
@@ -61,7 +61,7 @@ export interface StatusBadgeProps extends BreakpointSupport<StatusBadgePropsBrea
 }
 
 export const StatusBadge = (props: StatusBadgeProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     color = 'neutral',
     variant = 'filled',

--- a/libs/react-components/src/tedi/components/tags/tag/tag.tsx
+++ b/libs/react-components/src/tedi/components/tags/tag/tag.tsx
@@ -41,7 +41,7 @@ export interface TagProps extends BreakpointSupport<TagBreakpointProps> {
 }
 
 export const Tag = (props: TagProps): JSX.Element => {
-  const { getCurrentBreakpointProps } = useBreakpointProps();
+  const { getCurrentBreakpointProps } = useBreakpointProps(props.defaultServerBreakpoint);
   const {
     children,
     className,

--- a/libs/react-components/src/tedi/helpers/hooks/use-breakpoint-props.ts
+++ b/libs/react-components/src/tedi/helpers/hooks/use-breakpoint-props.ts
@@ -1,10 +1,10 @@
-import { pickBy } from 'lodash-es';
+import { omit, pickBy } from 'lodash-es';
 import React from 'react';
 
 import useBreakpoint, { Breakpoint, breakpoints } from './use-breakpoint';
 
-export const useBreakpointProps = () => {
-  const currentBreakpoint = useBreakpoint();
+export const useBreakpointProps = (defaultServerBreakpoint: Breakpoint = 'xs') => {
+  const currentBreakpoint = useBreakpoint(defaultServerBreakpoint);
   const activeBreakpoints: Breakpoint[] = React.useMemo(
     () => (currentBreakpoint ? breakpoints.slice(0, breakpoints.indexOf(currentBreakpoint) + 1) : []),
     [currentBreakpoint]
@@ -19,13 +19,15 @@ export const useBreakpointProps = () => {
     <T>(
       props: BreakpointSupport<T>,
       defaultValues: Partial<T> = {}
-    ): Omit<BreakpointSupport<T>, Exclude<Breakpoint, 'xs'>> => {
+    ): Omit<BreakpointSupport<T>, Exclude<Breakpoint, 'xs'> | 'defaultServerBreakpoint'> => {
       const { sm, md, lg, xl, xxl, ...xs } = props;
       const propArray = [
         ...activeBreakpoints.map((bp) => pickBy(bp === 'xs' ? xs : props[bp], (value) => value !== undefined)), // filter out props that have undefined as value, so they don't override lower breakpoint values or default values
       ].filter(Boolean);
 
-      return Object.assign(defaultValues, ...propArray);
+      // Add propArray to defaultValues
+      // and remove defaultServerBreakpoint from defaultValues - to avoided passing to HTML element with rest props
+      return Object.assign(omit(defaultValues, 'defaultServerBreakpoint'), ...propArray);
     },
     [activeBreakpoints]
   );
@@ -33,6 +35,18 @@ export const useBreakpointProps = () => {
   return { getCurrentBreakpointProps };
 };
 
+/**
+ * BreakpointSupport is a utility type that allows you to define props for different breakpoints.
+ * It extends the given type T and adds optional properties for each breakpoint except 'xs'.
+ * This is useful for creating responsive components that can have different props based on the current breakpoint.
+ * Also defaultSSRBreakpoint is added to the type, so you can set a default value for the component, when it's rendered on the server-side.
+ * Because in SSR we don't have access to the window object and can't know the user's screen size.
+ */
 export type BreakpointSupport<T> = T & {
+  /**
+   * Default breakpoint for SSR, the component is rendered with this breakpoint props on the server-side.
+   */
+  defaultServerBreakpoint?: Breakpoint;
+} & {
   [key in Exclude<Breakpoint, 'xs'>]?: Partial<T>;
 };

--- a/libs/react-components/src/tedi/helpers/hooks/use-breakpoint-props.ts
+++ b/libs/react-components/src/tedi/helpers/hooks/use-breakpoint-props.ts
@@ -20,6 +20,7 @@ export const useBreakpointProps = (defaultServerBreakpoint: Breakpoint = 'xs') =
       props: BreakpointSupport<T>,
       defaultValues: Partial<T> = {}
     ): Omit<BreakpointSupport<T>, Exclude<Breakpoint, 'xs'> | 'defaultServerBreakpoint'> => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
       const { sm, md, lg, xl, xxl, ...xs } = props;
       const propArray = [
         ...activeBreakpoints.map((bp) => pickBy(bp === 'xs' ? xs : props[bp], (value) => value !== undefined)), // filter out props that have undefined as value, so they don't override lower breakpoint values or default values

--- a/libs/react-components/src/tedi/helpers/hooks/use-breakpoint.ts
+++ b/libs/react-components/src/tedi/helpers/hooks/use-breakpoint.ts
@@ -1,16 +1,39 @@
 import { debounce } from 'lodash-es';
-import { useEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 export const breakpoints: Breakpoint[] = ['xs', 'sm', 'md', 'lg', 'xl', 'xxl'];
 
-export const useBreakpoint = (): Breakpoint | null => {
-  const [breakpoint, setBreakpoint] = useState(getBreakpoint());
+/**
+ * @param defaultServerBreakpoint - Default breakpoint for SSR, the hook returns this breakpoint in the SSR.
+ * @returns User's current breakpoint
+ */
+export const useBreakpoint = (defaultServerBreakpoint: Breakpoint = 'xs'): Breakpoint => {
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>(defaultServerBreakpoint);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    const getBreakpoint = (): Breakpoint => {
+      if (window.matchMedia('(min-width: 1400px)').matches) {
+        return 'xxl';
+      } else if (window.matchMedia('(min-width: 1200px)').matches) {
+        return 'xl';
+      } else if (window.matchMedia('(min-width: 992px)').matches) {
+        return 'lg';
+      } else if (window.matchMedia('(min-width: 768px)').matches) {
+        return 'md';
+      } else if (window.matchMedia('(min-width: 576px)').matches) {
+        return 'sm';
+      } else {
+        return 'xs';
+      }
+    };
+
     const resizeEvent = debounce((): void => {
       setBreakpoint(getBreakpoint());
     }, 20);
+
+    // Set the initial breakpoint on the client
+    setBreakpoint(getBreakpoint());
 
     window.addEventListener('resize', resizeEvent);
     return () => {
@@ -18,28 +41,6 @@ export const useBreakpoint = (): Breakpoint | null => {
       window.removeEventListener('resize', resizeEvent);
     };
   }, []);
-
-  return breakpoint;
-};
-
-const getBreakpoint = (): Breakpoint | null => {
-  let breakpoint: Breakpoint | null = null;
-
-  if (typeof window !== 'undefined') {
-    if (window.matchMedia('(min-width: 1400px)').matches) {
-      breakpoint = 'xxl';
-    } else if (window.matchMedia('(min-width: 1200px)').matches) {
-      breakpoint = 'xl';
-    } else if (window.matchMedia('(min-width: 992px)').matches) {
-      breakpoint = 'lg';
-    } else if (window.matchMedia('(min-width: 768px)').matches) {
-      breakpoint = 'md';
-    } else if (window.matchMedia('(min-width: 576px)').matches) {
-      breakpoint = 'sm';
-    } else {
-      breakpoint = 'xs';
-    }
-  }
 
   return breakpoint;
 };


### PR DESCRIPTION
- remove window usage in default state
- remove typeof window !== 'undefined inside useEffect as useEffect is always run on the client-side
- switch from useEffect to useLayoutEffect - which ensures that when component is rendered client-side only the first paint is done with correct props.
- Pass defaultBreakpoint to useBreakpointProps and set it default as "xs" - mobile-first approach
- Extend BreakpointSupport with defaultServerBreakpoint property and use it in every component that uses it, to allow passing different breakpoint than "xs"
- remove defaultServerBreakpoint from getCurrentBreakpointProps to avoid passing it to html elements