### PR TITLE
fix(modal): remove of untagged template literals for compatibility #776

### DIFF
--- a/libs/angular-components/community/components/overlay/modal/modal.component.html
+++ b/libs/angular-components/community/components/overlay/modal/modal.component.html
@@ -1,7 +1,4 @@
-<div
-  [class]="['tedi-modal__container',
-  `tedi-modal__container--${this.maxWidth()}`]"
->
+<div [class]="containerClasses()">
   <ng-content select="tedi-modal-header" />
   <div class="tedi-modal__content">
     <ng-content />

--- a/libs/angular-components/community/components/overlay/modal/modal.component.ts
+++ b/libs/angular-components/community/components/overlay/modal/modal.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  computed,
   inject,
   model,
   OnInit,
@@ -40,6 +41,14 @@ export class ModalComponent implements OnInit {
   readonly dialogRef = inject(DialogRef, { optional: true });
   readonly dialogData = inject(DIALOG_DATA, {
     optional: true,
+  });
+
+  readonly containerClasses = computed(() => {
+    const classes = ["tedi-modal__container"];
+    if (this.maxWidth()) {
+      classes.push(`tedi-modal__container--${this.maxWidth()}`);
+    }
+    return classes.join(" ");
   });
 
   ngOnInit(): void {


### PR DESCRIPTION
remove untagged template literals from the modal for compatibility with older versions of angular