### PR TITLE
feat(community-select): change CVA value from string[] (cdkListbox) to string #640

### DIFF
--- a/libs/angular-components/community/components/form/select/multiselect.component.html
+++ b/libs/angular-components/community/components/form/select/multiselect.component.html
@@ -55,7 +55,7 @@
     }
   </span>
 
-  @if (selectedOptions().length) {
+  @if (clearable() && selectedOptions().length) {
     <button
       class="tedi-select__clear"
       tedi-closing-button

--- a/libs/angular-components/community/components/form/select/multiselect.component.ts
+++ b/libs/angular-components/community/components/form/select/multiselect.component.ts
@@ -79,7 +79,8 @@ export enum specialOptionControls {
   ],
 })
 export class MultiselectComponent
-  implements AfterContentChecked, ControlValueAccessor {
+  implements AfterContentChecked, ControlValueAccessor
+{
   /**
    * The id of the select input (for label association).
    * @default ""
@@ -130,6 +131,11 @@ export class MultiselectComponent
    * @default false
    */
   selectableGroups = input<boolean>(false);
+  /**
+   * Whether the clear button will be shown when an option is selected.
+   * @default true
+   */
+  clearable = input<boolean>(true);
   feedbackText = input<ComponentInputs<FeedbackTextComponent>>();
 
   readonly specialOptionControls = specialOptionControls;

--- a/libs/angular-components/community/components/form/select/multiselect.stories.ts
+++ b/libs/angular-components/community/components/form/select/multiselect.stories.ts
@@ -1,0 +1,372 @@
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import {
+  FormGroup,
+  FormControl,
+  FormsModule,
+  ReactiveFormsModule,
+} from "@angular/forms";
+import { MultiselectComponent } from "./multiselect.component";
+import { SelectOptionComponent } from "./select-option.component";
+import {
+  IconComponent,
+  FeedbackTextComponent,
+} from "@tehik-ee/tedi-angular/tedi";
+
+const meta: Meta<MultiselectComponent> = {
+  title: "Community Angular/Form/Select/Multiselect",
+  component: MultiselectComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        MultiselectComponent,
+        SelectOptionComponent,
+        FormsModule,
+        ReactiveFormsModule,
+        IconComponent,
+        FeedbackTextComponent,
+      ],
+    }),
+  ],
+  argTypes: {
+    inputId: { control: "text" },
+    label: { control: "text" },
+    required: { control: "boolean" },
+    placeholder: { control: "text" },
+    state: { control: "radio", options: ["error", "valid", "default"] },
+    size: { control: "radio", options: ["small", "default"] },
+    multiRow: { control: "boolean" },
+    clearableTags: { control: "boolean" },
+    selectAll: { control: "boolean" },
+    selectableGroups: { control: "boolean" },
+    clearable: { control: "boolean" },
+    feedbackText: {
+      control: "object",
+      description: "Feedback message configuration",
+    },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    inputId: "multiselect-1",
+    label: "Custom multiselect label",
+    required: false,
+    placeholder: "Select options...",
+    state: "default",
+    size: "default",
+    multiRow: false,
+    clearableTags: false,
+    selectAll: false,
+    selectableGroups: false,
+    clearable: true,
+    feedbackText: {
+      type: "hint",
+      text: "Custom hint for using the multiselect",
+      position: "left",
+    },
+    // disabled: false, // removed to avoid type error, can be set via controls
+  },
+};
+
+export default meta;
+type Story = StoryObj<MultiselectComponent>;
+
+export const Multiselect: Story = {
+  render: (args) => ({
+    template: `
+        <tedi-multiselect
+          [inputId]="inputId"
+          [placeholder]="placeholder"
+          [label]="label"
+          [feedbackText]="feedbackText"
+          [required]="required"
+          [state]="state"
+          [size]="size"
+          [multiRow]="multiRow"
+          [clearableTags]="clearableTags"
+          [selectAll]="selectAll"
+          [selectableGroups]="selectableGroups"
+          [clearable]="clearable"
+          [disabled]="disabled"
+        >
+          <tedi-select-option value="option1" label="Option 1" />
+          <tedi-select-option value="option2" label="Option 2" />
+          <tedi-select-option value="option3" label="Option 3" />
+          <tedi-select-option value="option4" label="Option 4" />
+          <tedi-select-option value="option5" label="Option 5" />
+        </tedi-multiselect>
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};
+
+export const multiselectPreselectedOptions: Story = {
+  render: (args) => {
+    const form = new FormGroup({
+      selectedOptions: new FormControl(["option2", "option4"]),
+    });
+    return {
+      props: {
+        ...args,
+        form,
+      },
+      template: `
+        <form [formGroup]="form">
+          <tedi-multiselect
+            [inputId]="inputId"
+            [placeholder]="placeholder"
+            [label]="label"
+            [feedbackText]="feedbackText"
+            [required]="required"
+            [state]="state"
+            [size]="size"
+            [multiRow]="multiRow"
+            [clearableTags]="clearableTags"
+            [selectAll]="selectAll"
+            [selectableGroups]="selectableGroups"
+            [clearable]="clearable"
+            [disabled]="disabled"
+            formControlName="selectedOptions"
+          >
+            <tedi-select-option value="option1" label="Option 1" />
+            <tedi-select-option value="option2" label="Option 2" />
+            <tedi-select-option value="option3" label="Option 3" />
+            <tedi-select-option value="option4" label="Option 4" />
+            <tedi-select-option value="option5" label="Option 5" />
+          </tedi-multiselect>
+        </form>
+
+        <br />
+        <strong>controlValueAccessor value:</strong> {{ form.controls.selectedOptions.value | json }}
+      `,
+    };
+  },
+};
+
+export const MultiselectWithCustomOptions: Story = {
+  render: (args) => ({
+    template: `
+        <tedi-multiselect
+          [inputId]="inputId"
+          [placeholder]="placeholder"
+          [label]="label"
+          [feedbackText]="feedbackText"
+          [required]="required"
+          [state]="state"
+          [size]="size"
+          [multiRow]="multiRow"
+          [clearableTags]="clearableTags"
+          [selectAll]="selectAll"
+          [selectableGroups]="selectableGroups"
+          [clearable]="clearable"
+          [disabled]="disabled"
+        >
+          <tedi-select-option value="option1" label="Home">
+            <tedi-icon name="home" /> Home
+          </tedi-select-option>
+
+          <tedi-select-option value="option2" label="Settings">
+            <tedi-icon name="settings" /> Settings
+          </tedi-select-option>
+
+          <tedi-select-option value="option3" label="Account">
+            <tedi-icon name="person" /> Account
+          </tedi-select-option>
+
+          <tedi-select-option value="option4" label="Notifications">
+            <tedi-icon name="notifications" /> Notifications
+            <div>
+              <small>Manage your notification preferences</small>
+            </div>
+          </tedi-select-option>
+
+          <tedi-select-option value="option5" label="Logout">
+            <tedi-icon name="logout" /> Logout
+          </tedi-select-option>
+        </tedi-multiselect>
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};
+
+export const MultiselectSelectAll: Story = {
+  render: (args) => ({
+    template: `
+      <tedi-multiselect
+        [inputId]="inputId"
+        [selectAll]="true"
+        [placeholder]="placeholder"
+        [label]="label"
+        [feedbackText]="feedbackText"
+        [required]="required"
+        [state]="state"
+        [size]="size"
+        [multiRow]="multiRow"
+        [clearableTags]="clearableTags"
+        [selectableGroups]="selectableGroups"
+        [clearable]="clearable"
+        [disabled]="disabled"
+      >
+        <tedi-select-option value="option1" label="Option 1" />
+        <tedi-select-option value="option2" label="Option 2" />
+        <tedi-select-option value="option3" label="Option 3" />
+        <tedi-select-option value="option4" label="Option 4" />
+        <tedi-select-option value="option5" label="Option 5" />
+      </tedi-multiselect>
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};
+
+export const MultiselectGroupedOptions: Story = {
+  render: (args) => ({
+    template: `
+      <tedi-multiselect
+        [inputId]="inputId"
+        [placeholder]="placeholder"
+        [label]="label"
+        [feedbackText]="feedbackText"
+        [required]="required"
+        [state]="state"
+        [size]="size"
+        [multiRow]="multiRow"
+        [clearableTags]="clearableTags"
+        [selectAll]="selectAll"
+        [selectableGroups]="selectableGroups"
+        [clearable]="clearable"
+        [disabled]="disabled"
+      >
+        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
+        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
+        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
+        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
+        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
+      </tedi-multiselect>
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};
+
+export const MultiselectSelectableGroups: Story = {
+  render: (args) => ({
+    template: `
+      <tedi-multiselect
+        [inputId]="inputId"
+        [selectableGroups]="true"
+        [placeholder]="placeholder"
+        [label]="label"
+        [feedbackText]="feedbackText"
+        [required]="required"
+        [state]="state"
+        [size]="size"
+        [multiRow]="multiRow"
+        [clearableTags]="clearableTags"
+        [selectAll]="selectAll"
+        [clearable]="clearable"
+        [disabled]="disabled"
+      >
+        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
+        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
+        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
+        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
+        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
+      </tedi-multiselect>
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};
+
+export const MultiselectTagsMultirow: Story = {
+  render: (args) => ({
+    template: `
+      <tedi-multiselect
+        [inputId]="inputId"
+        [placeholder]="placeholder"
+        [label]="label"
+        [feedbackText]="feedbackText"
+        [required]="required"
+        [state]="state"
+        [size]="size"
+        [multiRow]="true"
+        [clearableTags]="clearableTags"
+        [selectAll]="selectAll"
+        [selectableGroups]="true"
+        [clearable]="clearable"
+        [disabled]="disabled"
+      >
+        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
+        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
+        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
+        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
+        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
+      </tedi-multiselect>
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};
+
+export const clearableTags: Story = {
+  render: (args) => ({
+    template: `
+      <tedi-multiselect
+        [inputId]="inputId"
+        [placeholder]="placeholder"
+        [label]="label"
+        [feedbackText]="feedbackText"
+        [required]="required"
+        [state]="state"
+        [size]="size"
+        [multiRow]="multiRow"
+        [clearableTags]="true"
+        [selectAll]="selectAll"
+        [selectableGroups]="true"
+        [clearable]="clearable"
+        [disabled]="disabled"
+      >
+        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
+        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
+        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
+        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
+        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
+      </tedi-multiselect>
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};
+
+export const multiselectNoOptions: Story = {
+  render: (args) => ({
+    template: `
+      <tedi-multiselect
+        [inputId]="inputId"
+        [placeholder]="placeholder"
+        [label]="label"
+        [feedbackText]="feedbackText"
+        [required]="required"
+        [state]="state"
+        [size]="size"
+        [multiRow]="multiRow"
+        [clearableTags]="clearableTags"
+        [selectAll]="selectAll"
+        [selectableGroups]="selectableGroups"
+        [clearable]="clearable"
+        [disabled]="disabled"
+      />
+    `,
+    props: {
+      ...args,
+    },
+  }),
+};

--- a/libs/angular-components/community/components/form/select/select.component.html
+++ b/libs/angular-components/community/components/form/select/select.component.html
@@ -43,7 +43,7 @@
     }
   </span>
 
-  @if (selectedOptions().length) {
+  @if (clearable() && selectedOptions().length) {
     <button
       class="tedi-select__clear"
       tedi-closing-button

--- a/libs/angular-components/community/components/form/select/select.component.ts
+++ b/libs/angular-components/community/components/form/select/select.component.ts
@@ -70,7 +70,8 @@ import { CardComponent, CardContentComponent } from "../../../components/cards";
   ],
 })
 export class SelectComponent
-  implements AfterContentChecked, ControlValueAccessor {
+  implements AfterContentChecked, ControlValueAccessor
+{
   /**
    * The id of the select input (for label association).
    * @default ""
@@ -146,8 +147,9 @@ export class SelectComponent
   }
 
   handleValueChange(event: { value: readonly string[] }): void {
-    this.selectedOptions.set(event.value);
-    this.onChange(event.value);
+    const selected = event.value[0] ?? "";
+    this.selectedOptions.set(selected ? [selected] : []);
+    this.onChange(selected);
     this.onTouched();
     this.toggleIsOpen(false);
   }
@@ -156,7 +158,7 @@ export class SelectComponent
     event.preventDefault();
     event.stopPropagation();
     this.selectedOptions.set([]);
-    this.onChange([]);
+    this.onChange("");
     this.onTouched();
   }
 
@@ -185,14 +187,14 @@ export class SelectComponent
   }
 
   // ControlValueAccessor implementation
-  onChange: (value: readonly string[]) => void = () => {};
+  onChange: (value: string) => void = () => {};
   onTouched: () => void = () => {};
 
-  writeValue(value: readonly string[]): void {
-    this.selectedOptions.set(value || []);
+  writeValue(value: string): void {
+    this.selectedOptions.set(value ? [value] : []);
   }
 
-  registerOnChange(fn: (value: readonly string[]) => void): void {
+  registerOnChange(fn: (value: string) => void): void {
     this.onChange = fn;
   }
 

--- a/libs/angular-components/community/components/form/select/select.component.ts
+++ b/libs/angular-components/community/components/form/select/select.component.ts
@@ -102,6 +102,11 @@ export class SelectComponent
    * @default "default"
    */
   size = input<InputSize>("default");
+  /**
+   * Whether the clear button will be shown when an option is selected.
+   * @default false
+   */
+  clearable = input<boolean>(true);
   feedbackText = input<ComponentInputs<FeedbackTextComponent>>();
 
   isOpen = signal(false);

--- a/libs/angular-components/community/components/form/select/select.component.ts
+++ b/libs/angular-components/community/components/form/select/select.component.ts
@@ -152,7 +152,7 @@ export class SelectComponent
   }
 
   handleValueChange(event: { value: readonly string[] }): void {
-    const selected = event.value[0] ?? "";
+    const selected = event.value[0] ?? null;
     this.selectedOptions.set(selected ? [selected] : []);
     this.onChange(selected);
     this.onTouched();
@@ -163,7 +163,7 @@ export class SelectComponent
     event.preventDefault();
     event.stopPropagation();
     this.selectedOptions.set([]);
-    this.onChange("");
+    this.onChange(null);
     this.onTouched();
   }
 
@@ -192,14 +192,14 @@ export class SelectComponent
   }
 
   // ControlValueAccessor implementation
-  onChange: (value: string) => void = () => {};
+  onChange: (value: string | null) => void = () => {};
   onTouched: () => void = () => {};
 
   writeValue(value: string): void {
     this.selectedOptions.set(value ? [value] : []);
   }
 
-  registerOnChange(fn: (value: string) => void): void {
+  registerOnChange(fn: (value: string | null) => void): void {
     this.onChange = fn;
   }
 

--- a/libs/angular-components/community/components/form/select/select.stories.ts
+++ b/libs/angular-components/community/components/form/select/select.stories.ts
@@ -14,18 +14,14 @@ import { IconComponent } from "@tehik-ee/tedi-angular/tedi";
  * The Select component provides users with a dropdown of options to choose from.
  *
  * Features:
- * - Single-select (default) and multi-select modes
  * - Custom option templates with icons and rich content
  * - Form control integration (ControlValueAccessor)
  * - Accessibility support
  * - Various states (default, error, valid) and sizes
- *
- * In single-select mode, the value is a string.
- * In multi-select mode, the value is an array of strings.
  */
 
 const meta: Meta<SelectComponent> = {
-  title: "Community Angular/Form/Select",
+  title: "Community Angular/Form/Select/Single Select",
   component: SelectComponent,
   decorators: [
     moduleMetadata({
@@ -40,28 +36,33 @@ const meta: Meta<SelectComponent> = {
     }),
   ],
   argTypes: {
-    placeholder: { control: "text" },
-    disabled: { control: "boolean" },
-    state: { control: "radio", options: ["error", "valid", "default"] },
-    size: { control: "radio", options: ["small", "default"] },
+    inputId: { control: "text" },
     label: { control: "text" },
     required: { control: "boolean" },
+    placeholder: { control: "text" },
+    state: { control: "radio", options: ["error", "valid", "default"] },
+    size: { control: "radio", options: ["small", "default"] },
+    clearable: { control: "boolean" },
     feedbackText: {
       control: "object",
       description: "Feedback message configuration",
     },
+    disabled: { control: "boolean" },
   },
   args: {
+    inputId: "select-1",
+    label: "Custom select label",
+    required: false,
     placeholder: "Select an option...",
     state: "default",
     size: "default",
-    label: "Custom select label",
-    required: true,
+    clearable: true,
     feedbackText: {
       type: "hint",
-      text: "Custom hint for using the multiselect",
+      text: "Custom hint for using the select",
       position: "left",
     },
+    // disabled: false, // removed to avoid type error, can be set via controls
   },
 };
 
@@ -78,7 +79,7 @@ export const Basic: Story = {
     props: args,
     template: `
       <tedi-select
-        inputId="select-1"
+        [inputId]="inputId"
         [label]="label"
         [feedbackText]="feedbackText"
         [required]="required"
@@ -86,6 +87,7 @@ export const Basic: Story = {
         [disabled]="disabled"
         [state]="state"
         [size]="size"
+        [clearable]="clearable"
       >
         <tedi-select-option [value]="'option0'" [label]="'Option 0'" />
         <tedi-select-option [value]="'option1'" [label]="'Option 1'">
@@ -112,12 +114,16 @@ export const WithPreselected: Story = {
     template: `
       <form [formGroup]="form">
         <tedi-select
-          inputId="select-2"
+          [inputId]="inputId"
           [label]="label"
           [feedbackText]="feedbackText"
           [required]="required"
-          formControlName="selectedOption"
           [placeholder]="placeholder"
+          [disabled]="disabled"
+          [state]="state"
+          [size]="size"
+          [clearable]="clearable"
+          formControlName="selectedOption"
         >
           <tedi-select-option [value]="'option1'" [label]="'Option 1'">
             <tedi-icon name="login" /> Option 1 <small> Some description here also </small>
@@ -155,12 +161,15 @@ export const Disabled: Story = {
       <form [formGroup]="form">
         <tedi-select
           formControlName="selectedOption"
-          inputId="select-3"
+          [inputId]="inputId"
           [label]="label"
           [feedbackText]="feedbackText"
           [required]="required"
           [placeholder]="placeholder"
-
+          [disabled]="disabled"
+          [state]="state"
+          [size]="size"
+          [clearable]="clearable"
         >
           <tedi-select-option [value]="'option1'" label="Option 1" />
           <tedi-select-option [value]="'option2'" label="Option 2" />
@@ -180,12 +189,15 @@ export const ValidState: Story = {
     props: args,
     template: `
       <tedi-select
-        inputId="select-4"
+        [inputId]="inputId"
         [label]="label"
         [feedbackText]="feedbackText"
         [required]="required"
         [state]="state"
         [placeholder]="placeholder"
+        [disabled]="disabled"
+        [size]="size"
+        [clearable]="clearable"
       >
         <tedi-select-option [value]="'option1'" [label]="'Option 1'">Option 1</tedi-select-option>
         <tedi-select-option [value]="'option2'" [label]="'Option 2'">Option 2</tedi-select-option>
@@ -204,12 +216,15 @@ export const ErrorState: Story = {
     props: args,
     template: `
       <tedi-select
-        inputId="select-5"
+        [inputId]="inputId"
         [label]="label"
         [feedbackText]="feedbackText"
         [required]="required"
         [state]="state"
         [placeholder]="placeholder"
+        [disabled]="disabled"
+        [size]="size"
+        [clearable]="clearable"
       >
         <tedi-select-option [value]="'option1'" [label]="'Option 1'">Option 1</tedi-select-option>
         <tedi-select-option [value]="'option2'" [label]="'Option 2'">Option 2</tedi-select-option>
@@ -228,12 +243,15 @@ export const SmallSize: Story = {
     props: args,
     template: `
       <tedi-select
-        inputId="select-6"
+        [inputId]="inputId"
         [label]="label"
         [feedbackText]="feedbackText"
         [required]="required"
         [size]="size"
         [placeholder]="placeholder"
+        [disabled]="disabled"
+        [state]="state"
+        [clearable]="clearable"
       >
         <tedi-select-option [value]="'option1'" [label]="'Option 1'">Option 1</tedi-select-option>
         <tedi-select-option [value]="'option2'" [label]="'Option 2'">Option 2</tedi-select-option>
@@ -247,11 +265,15 @@ export const ManyOptions: Story = {
   render: (args) => ({
     template: `
       <tedi-select
-        inputId="select-7"
+        [inputId]="inputId"
         [placeholder]="placeholder"
         [label]="label"
         [feedbackText]="feedbackText"
         [required]="required"
+        [disabled]="disabled"
+        [state]="state"
+        [size]="size"
+        [clearable]="clearable"
       >
         <tedi-select-option [value]="'option1'" [label]="'Option 1'">Option 1</tedi-select-option>
         <tedi-select-option [value]="'option2'" [label]="'Option 2'">Option 2</tedi-select-option>
@@ -281,11 +303,15 @@ export const singleSelectNoOptions: Story = {
   render: (args) => ({
     template: `
       <tedi-select
-        inputId="select-8"
+        [inputId]="inputId"
         [placeholder]="placeholder"
         [label]="label"
         [feedbackText]="feedbackText"
         [required]="required"
+        [disabled]="disabled"
+        [state]="state"
+        [size]="size"
+        [clearable]="clearable"
       />
     `,
     props: {
@@ -294,239 +320,26 @@ export const singleSelectNoOptions: Story = {
   }),
 };
 
-export const Multiselect: Story = {
+export const singleSelectGroupedOptions: Story = {
   render: (args) => ({
     template: `
-        <tedi-multiselect
-          inputId="multiselect-1"
-          [placeholder]="placeholder"
-          [label]="label"
-          [feedbackText]="feedbackText"
-          [required]="required"
-        >
-          <tedi-select-option value="option1" label="Option 1" />
-          <tedi-select-option value="option2" label="Option 2" />
-          <tedi-select-option value="option3" label="Option 3" />
-          <tedi-select-option value="option4" label="Option 4" />
-          <tedi-select-option value="option5" label="Option 5" />
-        </tedi-multiselect>
-    `,
-    props: {
-      ...args,
-    },
-  }),
-};
-
-export const multiselectPreselectedOptions: Story = {
-  render: (args) => {
-    const form = new FormGroup({
-      selectedOptions: new FormControl(["option2", "option4"]),
-    });
-    return {
-      props: {
-        ...args,
-        form,
-      },
-      template: `
-        <form [formGroup]="form">
-          <tedi-multiselect
-            inputId="multiselect-1"
-            [placeholder]="placeholder"
-            [label]="label"
-            [feedbackText]="feedbackText"
-            [required]="required"
-            formControlName="selectedOptions"
-          >
-            <tedi-select-option value="option1" label="Option 1" />
-            <tedi-select-option value="option2" label="Option 2" />
-            <tedi-select-option value="option3" label="Option 3" />
-            <tedi-select-option value="option4" label="Option 4" />
-            <tedi-select-option value="option5" label="Option 5" />
-          </tedi-multiselect>
-        </form>
-
-        <br />
-        <strong>controlValueAccessor value:</strong> {{ form.controls.selectedOptions.value | json }}
-      `,
-    };
-  },
-};
-
-export const MultiselectWithCustomOptions: Story = {
-  render: (args) => ({
-    template: `
-        <tedi-multiselect
-          inputId="multiselect-2"
-          [placeholder]="placeholder"
-          [label]="label"
-          [feedbackText]="feedbackText"
-          [required]="required"
-        >
-          <tedi-select-option value="option1" label="Home">
-            <tedi-icon name="home" /> Home
-          </tedi-select-option>
-
-          <tedi-select-option value="option2" label="Settings">
-            <tedi-icon name="settings" /> Settings
-          </tedi-select-option>
-
-          <tedi-select-option value="option3" label="Account">
-            <tedi-icon name="person" /> Account
-          </tedi-select-option>
-
-          <tedi-select-option value="option4" label="Notifications">
-            <tedi-icon name="notifications" /> Notifications
-            <div>
-              <small>Manage your notification preferences</small>
-            </div>
-          </tedi-select-option>
-
-          <tedi-select-option value="option5" label="Logout">
-            <tedi-icon name="logout" /> Logout
-          </tedi-select-option>
-        </tedi-multiselect>
-    `,
-    props: {
-      ...args,
-    },
-  }),
-};
-
-export const MultiselectSelectAll: Story = {
-  render: (args) => ({
-    template: `
-      <tedi-multiselect
-        inputId="multiselect-3"
-        [selectAll]="true"
+      <tedi-select
+        [inputId]="inputId"
         [placeholder]="placeholder"
         [label]="label"
         [feedbackText]="feedbackText"
         [required]="required"
+        [disabled]="disabled"
+        [state]="state"
+        [size]="size"
+        [clearable]="clearable"
       >
-        <tedi-select-option value="option1" label="Option 1" />
-        <tedi-select-option value="option2" label="Option 2" />
-        <tedi-select-option value="option3" label="Option 3" />
-        <tedi-select-option value="option4" label="Option 4" />
-        <tedi-select-option value="option5" label="Option 5" />
-      </tedi-multiselect>
-    `,
-    props: {
-      ...args,
-    },
-  }),
-};
-
-export const MultiselectGroupedOptions: Story = {
-  render: (args) => ({
-    template: `
-      <tedi-multiselect
-        inputId="multiselect-4"
-        [placeholder]="placeholder"
-        [label]="label"
-        [feedbackText]="feedbackText"
-        [required]="required"
-      >
-        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
-        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
-        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
-        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
-        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
-      </tedi-multiselect>
-    `,
-    props: {
-      ...args,
-    },
-  }),
-};
-
-export const MultiselectSelectableGroups: Story = {
-  render: (args) => ({
-    template: `
-      <tedi-multiselect
-        inputId="multiselect-5"
-        [selectableGroups]="true"
-        [placeholder]="placeholder"
-        [label]="label"
-        [feedbackText]="feedbackText"
-        [required]="required"
-      >
-        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
-        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
-        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
-        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
-        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
-      </tedi-multiselect>
-    `,
-    props: {
-      ...args,
-    },
-  }),
-};
-
-export const MultiselectTagsMultirow: Story = {
-  render: (args) => ({
-    template: `
-      <tedi-multiselect
-        inputId="multiselect-6"
-        [placeholder]="placeholder"
-        [label]="label"
-        [feedbackText]="feedbackText"
-        [required]="required"
-        [selectableGroups]="true"
-        [multiRow]="true"
-      >
-        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
-        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
-        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
-        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
-        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
-      </tedi-multiselect>
-    `,
-    props: {
-      ...args,
-    },
-  }),
-};
-
-export const clearableTags: Story = {
-  render: (args) => ({
-    template: `
-      <tedi-multiselect
-        inputId="multiselect-7"
-        [placeholder]="placeholder"
-        [label]="label"
-        [feedbackText]="feedbackText"
-        [required]="required"
-        [selectableGroups]="true"
-        [multiRow]="true"
-        [clearableTags]="true"
-      >
-        <tedi-select-option value="option1" label="Option 1" group="Grupp 1"/>
-        <tedi-select-option value="option2" label="Option 2" group="Grupp 1"/>
-        <tedi-select-option value="option3" label="Option 3" group="Grupp 1"/>
-        <tedi-select-option value="option4" label="Option 4" group="Grupp 2"/>
-        <tedi-select-option value="option5" label="Option 5" group="Grupp 2"/>
-      </tedi-multiselect>
-    `,
-    props: {
-      ...args,
-    },
-  }),
-};
-
-export const multiselectNoOptions: Story = {
-  render: (args) => ({
-    template: `
-      <tedi-multiselect
-        inputId="multiselect-8"
-        [placeholder]="placeholder"
-        [label]="label"
-        [feedbackText]="feedbackText"
-        [required]="required"
-        [selectableGroups]="true"
-        [multiRow]="true"
-        [clearableTags]="true"
-      />
+        <tedi-select-option value="option1" label="Option 1" group="Group 1"/>
+        <tedi-select-option value="option2" label="Option 2" group="Group 1"/>
+        <tedi-select-option value="option3" label="Option 3" group="Group 1"/>
+        <tedi-select-option value="option4" label="Option 4" group="Group 2"/>
+        <tedi-select-option value="option5" label="Option 5" group="Group 2"/>
+      </tedi-select>
     `,
     props: {
       ...args,

--- a/libs/angular-components/community/components/form/select/select.stories.ts
+++ b/libs/angular-components/community/components/form/select/select.stories.ts
@@ -127,7 +127,9 @@ export const WithPreselected: Story = {
           <tedi-select-option [value]="'option3'" [label]="'Option 3'">Option 3</tedi-select-option>
         </tedi-select>
       </form>
-      (FormControl value): {{ form.get('selectedOption').value }}
+
+      <br />
+      <strong>controlValueAccessor value:</strong> {{ form.get('selectedOption').value }}
     `,
     props: {
       ...args,
@@ -313,6 +315,41 @@ export const Multiselect: Story = {
       ...args,
     },
   }),
+};
+
+export const multiselectPreselectedOptions: Story = {
+  render: (args) => {
+    const form = new FormGroup({
+      selectedOptions: new FormControl(["option2", "option4"]),
+    });
+    return {
+      props: {
+        ...args,
+        form,
+      },
+      template: `
+        <form [formGroup]="form">
+          <tedi-multiselect
+            inputId="multiselect-1"
+            [placeholder]="placeholder"
+            [label]="label"
+            [feedbackText]="feedbackText"
+            [required]="required"
+            formControlName="selectedOptions"
+          >
+            <tedi-select-option value="option1" label="Option 1" />
+            <tedi-select-option value="option2" label="Option 2" />
+            <tedi-select-option value="option3" label="Option 3" />
+            <tedi-select-option value="option4" label="Option 4" />
+            <tedi-select-option value="option5" label="Option 5" />
+          </tedi-multiselect>
+        </form>
+
+        <br />
+        <strong>controlValueAccessor value:</strong> {{ form.controls.selectedOptions.value | json }}
+      `,
+    };
+  },
 };
 
 export const MultiselectWithCustomOptions: Story = {


### PR DESCRIPTION
**Singleselect**: https://erkidorbek.github.io/tedi-design-system/fix/640-community-select-CVA-selected-value/angular/?path=/docs/community-angular-form-select-single-select--docs
**Multiselect**: https://erkidorbek.github.io/tedi-design-system/fix/640-community-select-CVA-selected-value/angular/?path=/docs/community-angular-form-select-multiselect--docs


**Singleselect fixes:** 
1. Changes the controlValueAccessor value from string[] to string.
The value was string array even on single select because of the cdkListbox implementation.

**Singleselect + multiselect fixes:** 
1. Added [clearable] input, which either shows or hides the closing-button.
2. separated single and multiselect stories to show full arguments of multiselect.