### PR TITLE
fix(missing-var): add missing css variable in tedi-core

### DIFF
--- a/libs/tedi-core/src/variables/_font-variables.scss
+++ b/libs/tedi-core/src/variables/_font-variables.scss
@@ -40,6 +40,7 @@
   --body-regular-size-desktop: var(--size-02);
   --body-regular-size-mobile: var(--size-02);
   --body-regular-line-height-desktop: var(--line-height-03);
+  --body-regular-line-height-tablet: var(--line-height-03);
   --body-regular-line-height-mobile: var(--line-height-03);
   --family-primary-desktop: var(--family-roboto);
   --family-primary-mobile: var(--family-roboto);


### PR DESCRIPTION
add missing css variable in tedi-core to fix icon aligment issue, related to https://github.com/TEHIK-EE/tedi-design-system/pull/944