### PR TITLE
feat(choice-group-variant-export)

### DIFF
--- a/libs/angular-components/community/components/form/choicegroup/choicegroup.directive.ts
+++ b/libs/angular-components/community/components/form/choicegroup/choicegroup.directive.ts
@@ -1,6 +1,6 @@
 import { computed, Directive, input } from "@angular/core";
 
-type ChoicegroupVariant = "primary" | "secondary";
+export type ChoicegroupVariant = "primary" | "secondary";
 
 @Directive({
   standalone: true,


### PR DESCRIPTION
add a export for ChoicegroupVariant type from the directive of the same name, it's odd that it doesn't  have it