### PR TITLE
fix(community-search): Split search string by space and search all substrings #766

### DIFF
--- a/libs/angular-components/community/components/form/search/search.component.ts
+++ b/libs/angular-components/community/components/form/search/search.component.ts
@@ -211,11 +211,15 @@ export class SearchComponent
     const inputValue = this._inputValue();
     if (!inputValue) return this.autocompleteOptions();
 
-    return this.autocompleteOptions().filter(
-      (option) =>
-        option.label.toLowerCase().includes(inputValue.toLowerCase()) ||
-        option.description?.toLowerCase().includes(inputValue.toLowerCase()),
-    );
+    return this.autocompleteOptions().filter((option) => {
+      const searchString = inputValue.toLowerCase().split(" ");
+
+      return searchString.every(
+        (searchTerm) =>
+          option.label.toLowerCase().includes(searchTerm) ||
+          option.description?.toLowerCase().includes(searchTerm),
+      );
+    });
   });
 
   iconSize = computed(() => {

--- a/libs/angular-components/package-lock.json
+++ b/libs/angular-components/package-lock.json
@@ -8,8 +8,7 @@
       "name": "@tehik-ee/tedi-angular",
       "version": "0.0.0-semantic-version",
       "dependencies": {
-        "@tehik-ee/tedi-core": "^1.15.3",
-        "ngx-float-ui": "^19.0.1"
+        "@tehik-ee/tedi-core": "^1.15.3"
       },
       "devDependencies": {
         "@angular-devkit/core": "^19.2.14",
@@ -66,7 +65,8 @@
         "@angular/common": "^18.0.0 || ^19.0.0",
         "@angular/core": "^18.0.0 || ^19.0.0",
         "@angular/forms": "^18.0.0 || ^19.0.0",
-        "@angular/platform-browser": "^18.0.0 || ^19.0.0"
+        "@angular/platform-browser": "^18.0.0 || ^19.0.0",
+        "ngx-float-ui": "^19.0.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4006,6 +4006,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
       "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
@@ -4015,6 +4016,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
       "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.3",
         "@floating-ui/utils": "^0.2.10"
@@ -4024,7 +4026,8 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -17193,6 +17196,7 @@
       "integrity": "sha512-ST5fLsByQoT65CXiPFhnncQZjai8rCNqHC9rNDUh722a/UoummJaFGIC/SIM8tMkE6OK/sVOFqfskMre+7Nh8Q==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.6.12",
         "tslib": "^2.3.0"


### PR DESCRIPTION
Search needs to match all parts from search string, when the search string has spaces in string.
Search for each substring form the filter.

github pages:
https://erkidorbek.github.io/tedi-design-system/fix/766-community-search-split-search-string-search-all/angular/?path=/docs/community-angular-form-search--docs