### PR TITLE
fix/(file-dropzone): fix FormControl integration with file-dropzone

### DIFF
--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.html
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.html
@@ -20,13 +20,16 @@
   </div>
 </button>
 
-@if (helperText(); as message) {
-  <tedi-feedback-text
-    [text]="message.text"
-    [type]="message.type || 'hint'"
-    [position]="message.position || 'left'"
-  />
-}
+<ng-content select="[helper-text]">
+  @if (helperText(); as message) {
+    <tedi-feedback-text
+      [text]="message.text"
+      [type]="message.type || 'hint'"
+      [position]="message.position || 'left'"
+    />
+  }
+</ng-content>
+
 @for (file of files(); track file.name) {
   <div class="tedi-file-dropzone__file-list" [tediVerticalSpacing]="0.5">
     <tedi-card
@@ -40,12 +43,12 @@
     >
       <tedi-card-content class="tedi-file-dropzone__card" padding="xs">
         <div class="tedi-file-dropzone__file-name">
-          {{ file.name }}
+          {{ file.label ?? file.name }}
 
           @if (file && validateIndividually() && file.helper; as helper) {
             <tedi-tooltip [className]="tooltipClasses(file)">
               <tedi-tooltip-trigger>
-                <button tedi-info-button></button>
+                <button tedi-info-button [disabled]="file.disabled"></button>
               </tedi-tooltip-trigger>
 
               <tedi-tooltip-content [position]="helper?.position || 'top'">
@@ -66,6 +69,8 @@
   </div>
 }
 
-@if (this.uploadError(); as message) {
-  <tedi-feedback-text [text]="message" type="error" position="left" />
-}
+<ng-content select="[error-text]">
+  @if (this.uploadError(); as message) {
+    <tedi-feedback-text [text]="message" type="error" position="left" />
+  }
+</ng-content>

--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.ts
@@ -88,6 +88,8 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
   maxSize = input<number>(0);
   /**
    * Determines if multiple files can be uploaded at once via the file picker.
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/multiple
    * @default false
    **/
   multiple = input<boolean>(false);
@@ -126,7 +128,6 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
    *  @default "append"
    */
   mode = input<FileInputMode>("append");
-
   /**
    * If true, allows uploading folders instead of just files.
    * This enables the user to select a folder and upload all its contents.
@@ -147,16 +148,6 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
    * @default false
    */
   disabled = model<boolean>(false);
-  /**
-   * Provides helper text or feedback (such as an error or instruction message) to guide the user.
-   */
-  uploadError = model<string>();
-  /**
-   * Provides helper text or feedback (such as an error or instruction message) to guide the user.
-   * By default this is automatically generated based on the `accept` and `maxSize` inputs.
-   */
-  helperText = model<FeedbackTextProps>();
-
   /**
    * Output event triggered when files are added or changed.
    **/
@@ -202,6 +193,18 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
     return classList.join(" ");
   });
 
+  uploadError = signal<string | null>(null);
+
+  helperText = computed<FeedbackTextProps>(() => ({
+    text: getDefaultHelpers(
+      this.accept(),
+      this.maxSize(),
+      this._translationService.translate.bind(this._translationService)
+    ),
+    type: "hint",
+    position: "left",
+  }));
+
   constructor() {
     effect(() => {
       this._fileService.maxSize = this.maxSize();
@@ -240,17 +243,6 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
 
   ngOnInit(): void {
     this.addFiles(this.defaultFiles());
-    if (!this.helperText()) {
-      this.helperText.set({
-        text: getDefaultHelpers(
-          this.accept(),
-          this.maxSize(),
-          this._translationService.translate.bind(this._translationService)
-        ),
-        type: "hint",
-        position: "left",
-      });
-    }
   }
 
   selectionChange = (event: Event) => {

--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.ts
@@ -143,9 +143,11 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
     validateFileType,
   ]);
   /**
-   * Disables the file dropzone, preventing user interaction.
+   * If true, shows the file dropzone as in a erroring state with red border.
+   * Overrides default validation state.
    * @default false
-   */
+   **/
+  hasError = input<boolean>(false);
   /**
    * Output event triggered when files are added or changed.
    **/
@@ -177,7 +179,9 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
     if (this.disabled()) {
       classList.push("tedi-file-dropzone--disabled");
     }
-    if (this._uploadState() !== "none") {
+    if (this.hasError()) {
+      classList.push("tedi-file-dropzone--invalid");
+    } else if (this._uploadState() !== "none") {
       classList.push(`tedi-file-dropzone--${this._uploadState()}`);
     }
     if (this.isDragActive()) {

--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.ts
@@ -6,7 +6,6 @@ import {
   input,
   signal,
   viewChild,
-  model,
   ElementRef,
   effect,
   OnInit,
@@ -147,7 +146,6 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
    * Disables the file dropzone, preventing user interaction.
    * @default false
    */
-  disabled = model<boolean>(false);
   /**
    * Output event triggered when files are added or changed.
    **/
@@ -162,9 +160,7 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
 
   formatBytes = (bytes: number): string => formatBytes(bytes);
 
-  private _uploadState = computed(
-    () => this._fileService?.uploadState() || "none"
-  );
+  private _uploadState = computed(() => this._fileService.uploadState());
 
   private _onChange = (_: FileDropzone[]) => {};
   private _onTouched = () => {};
@@ -173,6 +169,7 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
   private _fileService = inject(FileService);
 
   isDragActive = signal<boolean>(false);
+  disabled = signal<boolean>(false);
 
   classes = computed(() => {
     const classList = ["tedi-file-dropzone"];
@@ -304,7 +301,7 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
 
     this._updateErrorState(error);
 
-    this._onChange(normalizedFiles);
+    this._onChange(this._fileService.files());
     this.fileChange.emit(normalizedFiles);
   }
 
@@ -312,6 +309,7 @@ export class FileDropzoneComponent implements ControlValueAccessor, OnInit {
     const error = this._fileService.removeFiles([file]);
     this._updateErrorState(error);
 
+    this._onChange(this._fileService.files());
     this.fileDelete.emit(file);
   }
 

--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.stories.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.stories.ts
@@ -54,6 +54,7 @@ const meta: Meta<FileDropzoneComponent> = {
     name: "file-dropzone",
     uploadFolder: false,
     validators: [validateFileSize, validateFileType],
+    hasError: false,
   },
   argTypes: {
     accept: {
@@ -86,9 +87,6 @@ const meta: Meta<FileDropzoneComponent> = {
     className: {
       description: `Additional CSS class names to apply to the dropzone for custom styling, which are added to the main containing button element.`,
     },
-    disabled: {
-      description: `Disables the file dropzone, preventing user interaction.`,
-    },
     mode: {
       control: {
         type: "radio",
@@ -107,6 +105,10 @@ const meta: Meta<FileDropzoneComponent> = {
       control: false,
       description:
         "Validation functions that can be used to validate files. Each function should return a string error message if validation fails, or undefined if it passes.",
+    },
+    hasError: {
+      description: `If true, shows the file dropzone as in a erroring state with red border.
+        Overrides default validation state.`,
     },
   },
 };

--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.stories.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.stories.ts
@@ -1,7 +1,13 @@
 import { ComponentInputs } from "tedi/types";
 import { FileDropzoneComponent } from "./file-dropzone.component";
-import { argsToTemplate, Meta, StoryObj } from "@storybook/angular";
+import {
+  argsToTemplate,
+  Meta,
+  moduleMetadata,
+  StoryObj,
+} from "@storybook/angular";
 import { validateFileSize, validateFileType } from "./utils";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 
 /**
  * FileDropzoneComponent is a component that allows users to drag and drop files or select them through a file input.
@@ -12,6 +18,12 @@ import { validateFileSize, validateFileType } from "./utils";
 
 const meta: Meta<FileDropzoneComponent> = {
   component: FileDropzoneComponent,
+  // import formcontrol module to enable usage inside forms
+  decorators: [
+    moduleMetadata({
+      imports: [ReactiveFormsModule],
+    }),
+  ],
   title: "Community/Form/FileDropzone",
   args: {
     accept: "",
@@ -27,7 +39,6 @@ const meta: Meta<FileDropzoneComponent> = {
     name: "file-dropzone",
     uploadFolder: false,
     validators: [validateFileSize, validateFileType],
-    uploadError: "",
   },
   argTypes: {
     accept: {
@@ -72,7 +83,7 @@ const meta: Meta<FileDropzoneComponent> = {
         Options are:
         - "append": Adds new files to the end of the list, keeping existing files
 
-        - "replace": Replaces existing files with new files of the same name"`,
+        - "replace": Replaces existing files with new files of the same name`,
     },
     uploadFolder: {
       description: ` If true, allows uploading folders instead of just files. This enables the user to select a folder and upload all its contents. Default file browser behaviour will prevent upload of files in this state.`,
@@ -82,10 +93,6 @@ const meta: Meta<FileDropzoneComponent> = {
       description:
         "Validation functions that can be used to validate files. Each function should return a string error message if validation fails, or undefined if it passes.",
     },
-    uploadError: {
-      description:
-        "An error message that can be set to indicate a problem with the file upload process. Displays a error like the validateIndividually validation error on false.",
-    },
   },
 };
 
@@ -93,24 +100,36 @@ export default meta;
 type Story = StoryObj<FileDropzoneComponent>;
 type StoryArgs = ComponentInputs<FileDropzoneComponent>;
 
-/** Replaces any same-name files, when usually it indexes them. */
-export const Replace: Story = {
-  render: (args) => ({
-    template: `<tedi-file-dropzone ${argsToTemplate(args)} />`,
-    props: args,
-  }),
-  args: {
-    mode: "replace",
-  },
-};
-
 const Template = (args: StoryArgs) => `
   <div>
     <div>
       <tedi-file-dropzone ${argsToTemplate(args)} />
     </div>
   </div>
-  `;
+`;
+
+/** Form-bound example, should work inside a reactive form. */
+export const Form: Story = {
+  render: (args) => {
+    const control = new FormControl(null);
+    return {
+      template: Template(args),
+      props: { ...args, control },
+    };
+  },
+  args: {
+    inputId: "file-dropzone-form-control",
+    name: "file-form-control",
+  },
+};
+
+/** Replaces any same-name files, when usually it indexes them. */
+export const Replace: Story = {
+  render: (args) => ({ template: Template(args), props: args }),
+  args: {
+    mode: "replace",
+  },
+};
 
 /** Custom un-translated label text. */
 export const WithHint: Story = {

--- a/libs/angular-components/community/components/form/file-dropzone/file.service.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file.service.ts
@@ -7,9 +7,7 @@ import {
 } from "./types";
 import { TediTranslationService } from "@tehik-ee/tedi-angular/tedi";
 
-@Injectable({
-  providedIn: "root",
-})
+@Injectable()
 export class FileService {
   maxSize = 0;
   accept = "";
@@ -22,8 +20,9 @@ export class FileService {
   private _translateService = inject(TediTranslationService);
 
   get files(): Signal<FileDropzone[]> {
-    return this._files;
+    return this._files.asReadonly();
   }
+
   public async addFiles(files: FileDropzone[] | File[]): Promise<string[]> {
     let newFiles = this.normalizeFiles(files);
     const currentFiles = this.files();
@@ -57,8 +56,8 @@ export class FileService {
       newFiles = newFiles.filter((file) => file.fileStatus !== "invalid");
     }
     const error = this._checkErrorState(newFiles);
-    this.uploadState.set(this._getNewState(!!error.length));
     this._files.set(newFiles);
+    this.uploadState.set(this._getNewState(!!error.length));
     return error;
   }
 

--- a/libs/angular-components/community/components/form/file-dropzone/types.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/types.ts
@@ -22,11 +22,11 @@ export class FileDropzone {
    */
   label?: string;
   /*
-   * Provides helper text or feedback (such as an error or instruction message) to guide the user.
+   * Provides a tooltip (such as an error or instruction message) to guide the user.
    */
   helper?: FeedbackTextProps;
   /*
-   * Disables the file button, preventing user interaction.
+   * Disables the file delete button, preventing user interaction.
    */
   disabled?: boolean;
   /*
@@ -37,7 +37,6 @@ export class FileDropzone {
    * Possible additional properties for the file, such as metadata.
    */
   metaData?: Record<string, unknown>;
-
   /*
    * The actual file object being uploaded.
    */


### PR DESCRIPTION
https://artur-langl.github.io/tedi-design-system/fix/file-dropzone/angular/?path=/docs/community-form-filedropzone--docs
all file-dropzone storybook stories now use a form control, adds a few slots for customization specifically on the feedback spots
removes disabled and uploadError inputs,
file-dropzone now respects formControl disabled state and supplies correct values to the control
file-dropzone has a input to override error behaviour