### PR TITLE
feat(file-dropzone): add toggle for SI and IEC standards of showing filesize

### DIFF
--- a/libs/angular-components/community/components/form/file-dropzone/constants.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/constants.ts
@@ -1,0 +1,20 @@
+const IECkiloBytes = 1024;
+const SIkiloBytes = 1000;
+
+const IECMegabytes = IECkiloBytes * IECkiloBytes;
+const SIMegabytes = SIkiloBytes * SIkiloBytes;
+
+export enum SIFileSize {
+  kB = SIkiloBytes,
+  MB = SIMegabytes,
+}
+
+export enum IECFileSize {
+  kB = IECkiloBytes,
+  MB = IECMegabytes,
+}
+
+export const FileSizeStandards = {
+  SI: SIFileSize,
+  IEC: IECFileSize,
+};

--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.html
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.component.html
@@ -2,12 +2,14 @@
   #fileInput
   class="tedi-file-dropzone__input"
   type="file"
+  [disabled]="disabled()"
   [multiple]="multiple()"
   [id]="inputId()"
   [attr.webkitdirectory]="uploadFolder() ? '' : null"
   [accept]="accept()"
   (change)="selectionChange($event)"
 />
+
 <button [className]="classes()" (click)="onContainerClick()">
   <div class="tedi-file-dropzone__label-wrapper">
     <tedi-icon

--- a/libs/angular-components/community/components/form/file-dropzone/file-dropzone.stories.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file-dropzone.stories.ts
@@ -19,7 +19,6 @@ import { ButtonComponent } from "tedi/components";
 
 const meta: Meta<FileDropzoneComponent> = {
   component: FileDropzoneComponent,
-  // import formcontrol module to enable usage inside forms
   decorators: [
     moduleMetadata({
       imports: [ReactiveFormsModule, ButtonComponent],
@@ -44,6 +43,7 @@ const meta: Meta<FileDropzoneComponent> = {
   args: {
     accept: "",
     maxSize: 0,
+    sizeDisplayStandard: "IEC",
     multiple: false,
     validateIndividually: false,
     defaultFiles: [],
@@ -65,12 +65,23 @@ const meta: Meta<FileDropzoneComponent> = {
     maxSize: {
       description: `The maximum file size allowed for upload, in bytes.`,
     },
+    sizeDisplayStandard: {
+      control: {
+        type: "radio",
+      },
+      options: ["SI", "IEC"],
+      description: `Specifies the standard to use when displaying file sizes or maximum file size.
+        Options are "SI" (base 10) or "IEC" (base 2).
+        \nSI units are in multiples of 1000 (e.g., 1 kB = 1000 bytes).
+        \nIEC units are in multiples of 1024 (e.g., 1 KiB = 1024 bytes).
+        https://wiki.ubuntu.com/UnitsPolicy`,
+    },
     multiple: {
       description: `Determines if multiple files can be uploaded at once via the file picker.`,
     },
     validateIndividually: {
       description: `If true, each file will be validated individually. If false, all files will be validated together.
-      Decides on what kind of UI elements are used to display validation errors.`,
+        Decides on what kind of UI elements are used to display validation errors.`,
     },
     defaultFiles: {
       description: `An array of default files that are preloaded in the upload list when the component is loaded.`,
@@ -94,9 +105,8 @@ const meta: Meta<FileDropzoneComponent> = {
       options: ["append", "replace"],
       description: `Specifies how to handle file name conflicts when multiple file of the same name are added.
         Options are:
-        - "append": Adds new files to the end of the list, keeping existing files
-
-        - "replace": Replaces existing files with new files of the same name`,
+        \n"append": Adds new files to the end of the list, keeping existing files
+        \n"replace": Replaces existing files with new files of the same name`,
     },
     uploadFolder: {
       description: ` If true, allows uploading folders instead of just files. This enables the user to select a folder and upload all its contents. Default file browser behaviour will prevent upload of files in this state.`,

--- a/libs/angular-components/community/components/form/file-dropzone/file.service.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/file.service.ts
@@ -3,17 +3,20 @@ import {
   DropzoneValidatorFunction,
   FileDropzone,
   FileInputMode,
+  SizeDisplayStandard,
   ValidationState,
 } from "./types";
 import { TediTranslationService } from "@tehik-ee/tedi-angular/tedi";
 
 @Injectable()
 export class FileService {
-  maxSize = 0;
-  accept = "";
-  mode: FileInputMode = "append";
+  maxSize = signal(0).asReadonly();
+  accept = signal("").asReadonly();
+  mode = signal<FileInputMode>("append").asReadonly();
+  validators = signal<DropzoneValidatorFunction[]>([]).asReadonly();
+  sizeDisplayStandard = signal<SizeDisplayStandard>("IEC").asReadonly();
+
   uploadState = signal<ValidationState>("none");
-  validators: DropzoneValidatorFunction[] = [];
 
   protected _files = signal<FileDropzone[]>([]);
 
@@ -27,7 +30,7 @@ export class FileService {
     let newFiles = this.normalizeFiles(files);
     const currentFiles = this.files();
 
-    switch (this.mode) {
+    switch (this.mode()) {
       case "append": {
         // index any duplicate name file
         newFiles = await this._renameDuplicates(currentFiles, newFiles);
@@ -110,12 +113,13 @@ export class FileService {
     const errors: string[] = [];
     for (const file of files) {
       file.helper = undefined;
-      const error = this.validators
+      const error = this.validators()
         .map((validator) =>
           validator(
-            this.maxSize,
-            this.accept,
+            this.maxSize(),
+            this.accept(),
             file,
+            this.sizeDisplayStandard(),
             this._translateService.translate.bind(this._translateService)
           )
         )

--- a/libs/angular-components/community/components/form/file-dropzone/types.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/types.ts
@@ -67,5 +67,8 @@ export type DropzoneValidatorFunction = (
   maxSize: number,
   acceptFileTypes: string,
   file: FileDropzone,
+  standard: SizeDisplayStandard,
   translate: (key: string, ...args: unknown[]) => string
 ) => string | undefined;
+
+export type SizeDisplayStandard = "SI" | "IEC";

--- a/libs/angular-components/community/components/form/file-dropzone/utils.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/utils.ts
@@ -1,21 +1,45 @@
-import { FileDropzone } from "./types";
+import { IECFileSize, SIFileSize } from "./constants";
+import { FileDropzone, SizeDisplayStandard } from "./types";
 
-/** SI Standard https://wiki.ubuntu.com/UnitsPolicy */
-export function formatBytes(bytes: number): string {
-  const MB = 100000;
-  const kB = 1000;
-  if (bytes > MB) {
-    return `${bytes / MB} MB`;
+export function formatBytes(
+  bytes: number,
+  standard: SizeDisplayStandard
+): string {
+  let kB: number = 0;
+  let MB: number = 0;
+
+  switch (standard) {
+    case "IEC":
+      kB = IECFileSize.kB;
+      MB = IECFileSize.MB;
+      break;
+    case "SI":
+      kB = SIFileSize.kB;
+      MB = SIFileSize.MB;
+      break;
+    default:
+      throw new Error(`Unknown standard: ${standard}`);
   }
-  if (bytes > kB) {
-    return `${bytes / kB} kB`;
+  if (bytes >= MB) {
+    const mbString = standard === "SI" ? "MB" : "MiB";
+    return `${roundNumber(bytes / MB)} ${mbString}`;
   }
-  return `${bytes} B`;
+  if (bytes >= kB) {
+    const bytesString = standard === "SI" ? "kB" : "KiB";
+    return `${roundNumber(bytes / kB)} ${bytesString}`;
+  }
+  return `${roundNumber(bytes)} B`;
+}
+
+export function roundNumber(num: number, decimals = 2): string {
+  const rounded = num.toFixed(decimals);
+  return rounded.includes(".") ? rounded.replace(/\.?0+$/, "") : rounded;
 }
 
 export function getDefaultHelpers(
   accept: string,
   maxSize: number,
+  standard: SizeDisplayStandard,
   translate?: (key: string, ...args: unknown[]) => string
 ): string {
   if (!translate)
@@ -30,7 +54,7 @@ export function getDefaultHelpers(
   }
   if (maxSize) {
     textArray.push(
-      `${translate("file-upload.max-size")} ${formatBytes(maxSize)}`
+      `${translate("file-upload.max-size")} ${formatBytes(maxSize, standard)}`
     );
   }
   return textArray.filter(Boolean).join(". ");
@@ -40,10 +64,11 @@ export function validateFileSize(
   maxSize: number,
   acceptFileTypes: string,
   file: FileDropzone,
+  standard: SizeDisplayStandard,
   translate: (key: string, ...args: unknown[]) => string
 ) {
   if (maxSize && file.size > maxSize) {
-    const maxSizeMB = formatBytes(maxSize);
+    const maxSizeMB = formatBytes(maxSize, standard);
     return translate(
       `file-upload.size-rejected-extended`,
       file.name,
@@ -57,6 +82,7 @@ export function validateFileType(
   maxSize: number,
   acceptFileTypes: string,
   file: FileDropzone,
+  standard: SizeDisplayStandard,
   translate: (key: string, ...args: unknown[]) => string
 ) {
   if (acceptFileTypes) {

--- a/libs/angular-components/community/components/form/file-dropzone/utils.ts
+++ b/libs/angular-components/community/components/form/file-dropzone/utils.ts
@@ -18,7 +18,7 @@ export function formatBytes(
       MB = SIFileSize.MB;
       break;
     default:
-      throw new Error(`Unknown standard: ${standard}`);
+      throw new Error(`Unknown filesize display standard: ${standard}`);
   }
   if (bytes >= MB) {
     const mbString = standard === "SI" ? "MB" : "MiB";
@@ -28,7 +28,7 @@ export function formatBytes(
     const bytesString = standard === "SI" ? "kB" : "KiB";
     return `${roundNumber(bytes / kB)} ${bytesString}`;
   }
-  return `${roundNumber(bytes)} B`;
+  return `${bytes} B`;
 }
 
 export function roundNumber(num: number, decimals = 2): string {


### PR DESCRIPTION
according to https://wiki.ubuntu.com/UnitsPolicy there's multiple standards of showing filesize, which is the SI (base 10) and IEC (base 2), so for SI 1 kB is 100 bytes, but for IEC 1 KiB is 1024 bytes
this adds the IEC standard as a option and enables it by default
plus some refactoring how the service shares it's configs with the component
https://artur-langl.github.io/tedi-design-system/fix/file-dropzone/angular/?path=/docs/community-form-filedropzone--docs